### PR TITLE
Prevent excessive retries

### DIFF
--- a/aiproxy/chatgpt.py
+++ b/aiproxy/chatgpt.py
@@ -194,6 +194,7 @@ class ChatGPTProxy(ProxyBase):
         *,
         api_key: str = None,
         async_client: AsyncClient = None,
+        max_retries: int = 0,
         request_filters: List[RequestFilterBase] = None,
         response_filters: List[ResponseFilterBase] = None,
         access_logger_queue: Queue
@@ -209,7 +210,8 @@ class ChatGPTProxy(ProxyBase):
             self.client = async_client
         else:
             self.client = AsyncClient(
-                api_key=api_key or os.getenv("OPENAI_API_KEY") or self._empty_openai_api_key
+                api_key=api_key or os.getenv("OPENAI_API_KEY") or self._empty_openai_api_key,
+                max_retries=max_retries
             )
 
     async def filter_request(self, request_id: str, request_json: dict, request_headers: dict) -> Union[dict, ChatCompletion, EventSourceResponse]:


### PR DESCRIPTION
Reduce excessive retry attempts by setting the default retry count to 0 for HTTP 500-series errors, preventing retries in both the client application and the proxy side.

If you do not want to retry on the proxy side, please set the maximum retry count using the `max_retries` parameter when instantiating the proxy.