### PR TITLE
Support Claude2 on AWS Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - ✅ Streaming support: Logs every bit of request and response data with token count – never miss a beat! 📊
 - ✅ Custom monitoring: Tailor-made for logging any specific info you fancy. Make it your own! 🔍
 - ✅ Custom filtering: Flexibly blocks access based on specific info or sends back your own responses. Be in control! 🛡️
+- ✅ Multiple AI Services: Supports ChatGPT (OpenAI and Azure OpenAI Service), Claude2 on AWS Bedrock, and is extensible by yourself! 🤖
 
 
 ## 🚀 Quick start
@@ -91,6 +92,36 @@ azure_client = openai.AsyncAzureOpenAI(
 )
 
 proxy = ChatGPTProxy(async_client=azure_client, access_logger_queue=worker.queue_client)
+```
+
+To use Claude2 on AWS Bedrock, instantiate `Claude2Proxy`.
+
+```python
+from aiproxy.claude2 import Claude2Proxy
+claude_proxy = Claude2Proxy(
+    aws_access_key_id="YOUR_AWS_ACCESS_KEY_ID",
+    aws_secret_access_key="YOUR_AWS_SECRET_ACCESS_KEY",
+    region_name="your-bedrock-region",
+    access_logger_queue=worker.queue_client
+)
+claude_proxy.add_route(app, "/model/anthropic.claude-v2")
+```
+
+Client side. We test API with boto3.
+
+```python
+import boto3
+import json
+# Make client with dummy creds
+session = boto3.Session(aws_access_key_id="dummy", aws_secret_access_key="dummy",)
+bedrock = session.client(service_name="bedrock-runtime", region_name="private", endpoint_url="http://127.0.0.1:8000")
+# Call API
+response = bedrock.invoke_model(
+    modelId="anthropic.claude-v2",
+    body=json.dumps({"prompt": "Human: うなぎとあなごの違いは？\nAssistant: ", "max_tokens_to_sample": 100})
+)
+# Show response
+print(json.loads(response["body"].read()))
 ```
 
 

--- a/aiproxy/claude2.py
+++ b/aiproxy/claude2.py
@@ -1,0 +1,359 @@
+import base64
+from datetime import datetime
+import json
+import logging
+import re
+import time
+import traceback
+from typing import List, Union
+from uuid import uuid4
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse, Response
+import httpx
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+from .proxy import ProxyBase, RequestFilterBase, ResponseFilterBase, RequestFilterException, ResponseFilterException
+from .accesslog import _AccessLogBase, RequestItemBase, ResponseItemBase, StreamChunkItemBase, ErrorItemBase
+from .queueclient import QueueClientBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class Claude2RequestItem(RequestItemBase):
+    def to_accesslog(self, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
+        return accesslog_cls(
+            request_id=self.request_id,
+            created_at=datetime.utcnow(),
+            direction="request",
+            content=self.request_json["prompt"],
+            raw_body=json.dumps(self.request_json, ensure_ascii=False),
+            raw_headers=json.dumps(self.request_headers, ensure_ascii=False),
+            model="anthropic.claude-v2"
+        )
+
+
+class Claude2ResponseItem(ResponseItemBase):
+    def to_accesslog(self, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
+        return accesslog_cls(
+            request_id=self.request_id,
+            created_at=datetime.utcnow(),
+            direction="response",
+            content=self.response_json["completion"],
+            function_call=None,
+            tool_calls=None,
+            raw_body=json.dumps(self.response_json, ensure_ascii=False),
+            raw_headers=json.dumps(self.response_headers, ensure_ascii=False),
+            model="anthropic.claude-v2",
+            prompt_tokens=self.response_headers.get("x-amzn-bedrock-input-token-count", 0),
+            completion_tokens=self.response_headers.get("x-amzn-bedrock-output-token-count", 0),
+            request_time=self.duration,
+            request_time_api=self.duration_api
+        )
+
+
+class Claude2StreamResponseItem(StreamChunkItemBase):
+    def to_accesslog(self, chunks: list, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
+        chunk_jsons = []
+        response_content = ""
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        # Parse info from chunks
+        for chunk in chunks:
+            chunk_jsons.append(chunk.chunk_json)
+            response_content += chunk.chunk_json["completion"] or ""
+
+        # Tokens
+        if len(chunk_jsons) > 0:
+            if "amazon-bedrock-invocationMetrics" in chunk_jsons[-1]:
+                prompt_tokens = chunk_jsons[-1]["amazon-bedrock-invocationMetrics"]["inputTokenCount"]
+                completion_tokens = chunk_jsons[-1]["amazon-bedrock-invocationMetrics"]["outputTokenCount"]
+            else:
+                # On error response in stream mode
+                prompt_tokens = self.response_headers.get("x-amzn-bedrock-input-token-count", 0)
+                completion_tokens = self.response_headers.get("x-amzn-bedrock-output-token-count", 0)
+
+        return accesslog_cls(
+            request_id=self.request_id,
+            created_at=datetime.utcnow(),
+            direction="error" if self.response_headers.get("x-amzn-errortype") else "response",
+            content=response_content,
+            function_call=None,
+            tool_calls=None,
+            raw_body=json.dumps(chunk_jsons, ensure_ascii=False),
+            raw_headers=json.dumps(self.response_headers, ensure_ascii=False),
+            model="anthropic.claude-v2",
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            request_time=self.duration,
+            request_time_api=self.duration_api
+        )
+
+
+class Claude2ErrorItem(ErrorItemBase):
+    ...
+
+
+queue_item_types = [Claude2RequestItem, Claude2ResponseItem, Claude2StreamResponseItem, Claude2ErrorItem]
+
+
+# Reverse proxy application for Claude2 on AWS Bedrock
+class Claude2Proxy(ProxyBase):
+    def __init__(
+        self,
+        *,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+        region_name: str = None,
+        timeout=60.0,
+        request_filters: List[RequestFilterBase] = None,
+        response_filters: List[ResponseFilterBase] = None,
+        access_logger_queue: QueueClientBase
+    ):
+        super().__init__(
+            request_filters=request_filters,
+            response_filters=response_filters,
+            access_logger_queue=access_logger_queue
+        )
+
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.region_name = region_name
+        self.aws_url = f"https://bedrock-runtime.{self.region_name}.amazonaws.com"
+
+        # AWS credentials
+        self.authorizer = SigV4Auth(
+            credentials=Credentials(
+                access_key=self.aws_access_key_id,
+                secret_key=self.aws_secret_access_key
+            ),
+            service_name="bedrock",
+            region_name=self.region_name
+        )
+
+        # HTTP Client (should close on end)
+        self.http_client = httpx.AsyncClient(timeout=timeout)
+
+    async def filter_request(self, request_id: str, request_json: dict, request_headers: dict, stream: bool) -> Union[dict, JSONResponse]:
+        for f in self.request_filters:
+            if completion_content := await f.filter(request_id, request_json, request_headers):
+                # Return response if filter returns JsonResponse
+                resp_for_log = {
+                    "completion": completion_content
+                }
+                # Response log
+                self.access_logger_queue.put(Claude2ResponseItem(
+                    request_id=request_id,
+                    response_json=resp_for_log,
+                    response_headers={
+                        "x-amzn-bedrock-input-token-count": 0,
+                        "x-amzn-bedrock-output-token-count": 0
+                    }
+                ))
+
+                if stream:
+                    logger.warning("Claude2Proxy doesn't support instant reply from RequestFilter. Return message as 400 bad request.")
+                    return self.return_response_with_headers(JSONResponse({"message": completion_content}, status_code=400), request_id)
+                else:
+                    return self.return_response_with_headers(JSONResponse(resp_for_log), request_id)
+
+        return request_json
+
+    async def filter_response(self, request_id: str, response_json: dict) -> dict:
+        for f in self.response_filters:
+            if immediately_return_json_resp := await f.filter(request_id, response_json):
+                return immediately_return_json_resp
+
+        return response_json
+
+    def get_aws_request_header_with_cred(self, url: str, bedrock_params: dict):
+        ar = AWSRequest(
+            method="POST",
+            url=url,
+            headers={
+                "Content-Type": "application/json",
+                "X-Amzn-Bedrock-Accept": "application/json",
+            },
+            data=json.dumps(bedrock_params).encode()
+        )
+        self.authorizer.add_auth(ar)
+        ar.prepare()
+        return ar.headers
+
+    def return_response_with_headers(self, resp: Response, request_id: str):
+        self.add_response_headers(response=resp, request_id=request_id)
+        return resp
+
+    def add_route(self, app: FastAPI, base_url: str):
+        @app.post(base_url + "/{invoke_method}")
+        async def handle_request(request: Request, invoke_method: str):
+            request_id = str(uuid4())
+
+            try:
+                start_time = time.time()
+                request_json = await request.json()
+                request_headers = dict(request.headers.items())
+
+                # Log request
+                self.access_logger_queue.put(Claude2RequestItem(
+                    request_id=request_id,
+                    request_json=request_json,
+                    request_headers=request_headers
+                ))
+
+                # Filter request
+                request_json = await self.filter_request(request_id, request_json, request_headers, invoke_method == "invoke-with-response-stream")
+                if isinstance(request_json, JSONResponse):
+                    return request_json
+
+                # Call API and handling response from API
+                url = f"{self.aws_url}/model/anthropic.claude-v2/{invoke_method}"
+                aws_request_header = self.get_aws_request_header_with_cred(url, request_json)
+                start_time_api = time.time()
+
+                if invoke_method == "invoke-with-response-stream":
+                    async def process_stream(stream_response: httpx.Response, status_code: int):
+                        try:
+                            async for chunk in stream_response.aiter_raw():
+                                # Parse JSON data from bytes chunk
+                                for m in re.findall(rb"event\{.*?\}", chunk):
+                                    b64bytes = json.loads(m[5:].decode("utf-8"))["bytes"]
+                                    chunk_json = json.loads(base64.b64decode(b64bytes).decode())
+                                    self.access_logger_queue.put(Claude2StreamResponseItem(
+                                        request_id=request_id,
+                                        chunk_json=chunk_json
+                                    ))
+
+                                yield chunk
+
+                            # Add hearedes for log
+                            self.return_response_with_headers(stream_response, request_id)
+
+                        finally:
+                            # Response log
+                            now = time.time()
+                            self.access_logger_queue.put(Claude2StreamResponseItem(
+                                request_id=request_id,
+                                response_headers=dict(stream_response.headers.items()),
+                                duration=now - start_time,
+                                duration_api=now - start_time_api,
+                                request_json=request_json
+                            ))
+
+                    stream_request = httpx.Request(method="POST", url=url, headers=dict(aws_request_header), json=request_json)
+                    stream_response = await self.http_client.send(request=stream_request, stream=True)
+
+                    # DO NOT raise status error here to return error info in stream
+
+                    return self.return_response_with_headers(StreamingResponse(
+                        process_stream(stream_response, stream_response.status_code),
+                        status_code=stream_response.status_code,
+                        headers=stream_response.headers
+                    ), request_id)
+
+                else:
+                    completion_response = await self.http_client.post(url=url, headers=dict(aws_request_header), json=request_json)
+                    completion_response.raise_for_status()
+
+                    duration_api = time.time() - start_time_api
+                    response_json = completion_response.json()
+
+                    # Filter response
+                    original_response_json = response_json.copy()
+                    filtered_response_json = await self.filter_response(request_id, response_json)
+
+                    # Make JSON response
+                    if original_response_json != filtered_response_json:
+                        json_response = JSONResponse(original_response_json, completion_response.status_code, completion_response.headers)
+                    else:
+                        # Remove incorrect content-length
+                        completion_response.headers.pop("Content-Length")
+                        json_response = JSONResponse(filtered_response_json, completion_response.status_code, completion_response.headers)
+
+                    self.add_response_headers(json_response, request_id)
+
+                    # Response log
+                    self.access_logger_queue.put(Claude2ResponseItem(
+                        request_id=request_id,
+                        response_json=filtered_response_json,
+                        response_headers=dict(json_response.headers.items()),
+                        duration=time.time() - start_time,
+                        duration_api=duration_api
+                    ))
+
+                    return json_response
+
+            # Error handlers
+            except RequestFilterException as rfex:
+                logger.error(f"Request filter error: {rfex}\n{traceback.format_exc()}")
+
+                resp_json = {"error": {"message": rfex.message, "type": "request_filter_error", "param": None, "code": None}}
+
+                # Error log
+                self.access_logger_queue.put(Claude2ErrorItem(
+                    request_id=request_id,
+                    exception=rfex,
+                    traceback_info=traceback.format_exc(),
+                    response_json=resp_json
+                ))
+
+                return self.return_response_with_headers(JSONResponse(resp_json, status_code=rfex.status_code), request_id)
+
+            except ResponseFilterException as rfex:
+                logger.error(f"Response filter error: {rfex}\n{traceback.format_exc()}")
+
+                resp_json = {"error": {"message": rfex.message, "type": "response_filter_error", "param": None, "code": None}}
+
+                # Error log
+                self.access_logger_queue.put(Claude2ErrorItem(
+                    request_id=request_id,
+                    exception=rfex,
+                    traceback_info=traceback.format_exc(),
+                    response_json=resp_json
+                ))
+
+                return self.return_response_with_headers(JSONResponse(resp_json, status_code=rfex.status_code), request_id)
+
+            except httpx.HTTPStatusError as htex:
+                logger.error(f"Error at server: {htex}\n{traceback.format_exc()}")
+
+                # Error log
+                try:
+                    resp_json = htex.response.json()
+                except:
+                    try:
+                        resp_json = str(await htex.response.aread())
+                    except:
+                        logger.warning("Error")
+
+                self.access_logger_queue.put(Claude2ErrorItem(
+                    request_id=request_id,
+                    exception=htex,
+                    traceback_info=traceback.format_exc(),
+                    response_json=resp_json
+                ))
+
+                htex.response.headers.pop("content-length")
+
+                return self.return_response_with_headers(JSONResponse(
+                    resp_json,
+                    status_code=htex.response.status_code,
+                    headers=htex.response.headers
+                ), request_id)
+
+            except Exception as ex:
+                logger.error(f"Error at server: {ex}\n{traceback.format_exc()}")
+
+                resp_json = {"error": {"message": "Proxy error", "type": "proxy_error", "param": None, "code": None}}
+
+                # Error log
+                self.access_logger_queue.put(Claude2ErrorItem(
+                    request_id=request_id,
+                    exception=ex,
+                    traceback_info=traceback.format_exc(),
+                    response_json=resp_json
+                ))
+
+                return self.return_response_with_headers(JSONResponse(resp_json, status_code=502), request_id)

--- a/tests/test_claude2.py
+++ b/tests/test_claude2.py
@@ -1,0 +1,372 @@
+import pytest
+from datetime import datetime
+import json
+import os
+from time import sleep
+from typing import Union
+from uuid import uuid4
+import boto3
+from botocore.exceptions import ClientError
+from aiproxy import (
+    AccessLog,
+    RequestFilterBase,
+    ResponseFilterBase
+)
+from aiproxy.accesslog import AccessLogWorker
+from aiproxy.claude2 import Claude2Proxy, Claude2RequestItem, Claude2ResponseItem, Claude2StreamResponseItem
+
+sqlite_conn_str = "sqlite:///aiproxy_test.db"
+postgresql_conn_str = f"postgresql://{os.getenv('PSQL_USER')}:{os.getenv('PSQL_PASSWORD')}@{os.getenv('PSQL_HOST')}:{os.getenv('PSQL_PORT')}/{os.getenv('PSQL_DATABASE')}"
+
+DB_CONNECTION_STR = sqlite_conn_str
+
+# Filters for test
+class OverwriteFilter(RequestFilterBase):
+    async def filter(self, request_id: str, request_json: dict, request_headers: dict) -> Union[str, None]:
+        request_model = request_json["model"]
+        if not request_model.startswith("anthropic.claude-v2"):
+            # Overwrite request_json
+            request_json["model"] = "anthropic.claude-v100-twinturbo"
+
+
+class ValueReturnFilter(RequestFilterBase):
+    async def filter(self, request_id: str, request_json: dict, request_headers: dict) -> Union[str, None]:
+        banned_user = ["uezo"]
+        user = request_json.get("user")
+
+        # Return string message to return response right after this filter ends (not to call ChatGPT)
+        if not user:
+            return "user is required"
+        elif user in banned_user:
+            return "you can't use this service"
+
+
+class OverwriteResponseFilter(ResponseFilterBase):
+    async def filter(self, request_id: str, response_json: dict) -> Union[dict, None]:
+        response_json["completion"] = "Overwrite in filter"
+        return response_json
+
+
+# Test data
+@pytest.fixture
+def prompt() -> list:
+    return '''\nHuman: うなぎとあなごの違いは？\nAssistant: '''
+
+@pytest.fixture
+def request_json(prompt):
+    return {
+        "prompt": prompt,
+        "max_tokens_to_sample": 200,
+    }
+
+@pytest.fixture
+def request_headers():
+    return {"user-agent": "Boto3/1.33.6 md/Botocore#1.33.6 ua/2.0 os/macos#22.6.0 md/arch#x86_64 lang/python#3.11.6 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.33.6"}
+
+@pytest.fixture
+def response_json():
+    return {'completion': ' うなぎとあなごの主な違いは以下の通りです。\n\n- 種類が違う。うなぎはウナギ科の魚類、あなごはアナゴ科の魚類である。\n\n- 生息場所が違う。うなぎは淡水や汽水域に生息するのに対し、あなごは海水域に生息する。 \n\n- 成長過程が違う。うなぎは淡水でシラスウナギやニホンウナギと呼ばれる稚魚期を過ごした後、海に下って成長する。一方、あな', 'stop_reason': 'max_tokens', 'stop': None}
+
+@pytest.fixture
+def response_headers_json():
+    return {'date': 'Sun, 10 Dec 2023 03:37:16 GMT', 'content-type': 'application/json', 'content-length': '535', 'connection': 'keep-alive', 'x-amzn-requestid': '1df60217-446e-4e2c-bc7b-0e41029eff63', 'x-amzn-bedrock-invocation-latency': '9170', 'x-amzn-bedrock-output-token-count': '200', 'x-amzn-bedrock-input-token-count': '25'}
+
+@pytest.fixture
+def response_headers_stream_json():
+    return {'date': 'Sun, 10 Dec 2023 03:38:46 GMT', 'content-type': 'application/vnd.amazon.eventstream', 'transfer-encoding': 'chunked', 'connection': 'keep-alive', 'x-amzn-requestid': 'bc5d2ef8-094e-4262-8368-52fbb4ac5dfc', 'x-amzn-bedrock-content-type': 'application/json'}
+
+@pytest.fixture
+def chunks_json():
+    return [
+        {'completion': ' ', 'stop_reason': None, 'stop': None},
+        {'completion': 'うなぎとあなごの主な違いは', 'stop_reason': None, 'stop': None},
+        {'completion': '以下の通りです。\n\n- 種類が異', 'stop_reason': None, 'stop': None},
+        {'completion': 'なる\n    - うなぎはウナ', 'stop_reason': None, 'stop': None},
+        {'completion': 'ギ目ウナギ科の魚', 'stop_reason': None, 'stop': None},
+        {'completion': '\n    - あなごはアナゴ目アナ', 'stop_reason': None, 'stop': None},
+        {'completion': 'ゴ科の魚', 'stop_reason': None, 'stop': None},
+        {'completion': '\n- 生息場所が異なる', 'stop_reason': None, 'stop': None},
+        {'completion': '\n    - うなぎは川や湖、湿地など', 'stop_reason': None, 'stop': None},
+        {'completion': 'の淡水に生息\n    - あなご', 'stop_reason': None, 'stop': None},
+        {'completion': 'は海に生息\n- 体型が異なる\n   ', 'stop_reason': None, 'stop': None},
+        {'completion': ' - うなぎは円筒形で体が', 'stop_reason': None, 'stop': None},
+        {'completion': '細長い\n    - あなご', 'stop_reason': None, 'stop': None},
+        {'completion': 'は側扁した体', 'stop_reason': None, 'stop': None},
+        {'completion': '型をしている\n- 食', 'stop_reason': None, 'stop': None},
+        {'completion': 'べ方が異なる\n    - うな', 'stop_reason': 'max_tokens', 'stop': None, 'amazon-bedrock-invocationMetrics': {'inputTokenCount': 25, 'outputTokenCount': 200, 'invocationLatency': 6858, 'firstByteLatency': 1824}}
+    ]
+
+
+def test_request_item_to_accesslog(prompt, request_json, request_headers):
+    request_id = str(uuid4())
+    item = Claude2RequestItem(request_id, request_json, request_headers)
+
+    accesslog = item.to_accesslog(AccessLog)
+
+    assert accesslog.request_id == request_id
+    assert isinstance(accesslog.created_at, datetime)
+    assert accesslog.direction == "request"
+    assert accesslog.content == prompt
+    assert accesslog.function_call is None
+    assert accesslog.tool_calls is None
+    assert accesslog.raw_body == json.dumps(request_json, ensure_ascii=False)
+    assert accesslog.raw_headers == json.dumps(request_headers, ensure_ascii=False)
+    assert accesslog.model == "anthropic.claude-v2"
+
+
+def test_request_item_to_from_json(prompt, request_json, request_headers):
+    request_id = str(uuid4())
+    item = Claude2RequestItem(request_id, request_json, request_headers)
+
+    item_json = item.to_json()
+    item_dict = json.loads(item_json)
+
+    assert item_dict["type"] == Claude2RequestItem.__name__
+    assert item_dict["request_id"] == request_id
+    assert item_dict["request_json"] == request_json
+    assert item_dict["request_headers"] == request_headers
+
+    item_restore = Claude2RequestItem.from_json(item_json)
+
+    assert item_restore.request_id == request_id
+    assert item_restore.request_json == request_json
+    assert item_restore.request_headers == request_headers    
+
+
+def test_response_item_to_accesslog(response_json, response_headers_json):
+    request_id = str(uuid4())
+    item = Claude2ResponseItem(request_id, response_json, response_headers_json, 1.0, 2.0)
+
+    accesslog = item.to_accesslog(AccessLog)
+
+    assert accesslog.request_id == request_id
+    assert isinstance(accesslog.created_at, datetime)
+    assert accesslog.direction == "response"
+    assert accesslog.content == response_json["completion"]
+    assert accesslog.function_call is None
+    assert accesslog.tool_calls is None
+    assert accesslog.raw_body == json.dumps(response_json, ensure_ascii=False)
+    assert accesslog.raw_headers == json.dumps(response_headers_json, ensure_ascii=False)
+    assert accesslog.model == "anthropic.claude-v2"
+    assert accesslog.prompt_tokens == response_headers_json["x-amzn-bedrock-input-token-count"]
+    assert accesslog.completion_tokens == response_headers_json["x-amzn-bedrock-output-token-count"]
+    assert accesslog.request_time == item.duration
+    assert accesslog.request_time_api == item.duration_api
+
+
+def test_stream_response_item_to_accesslog(chunks_json, response_headers_stream_json, request_json):
+    request_id = str(uuid4())
+    chunks = []
+    content = ""
+    for c in chunks_json:
+        chunks.append(Claude2StreamResponseItem(request_id, c))
+        content += c.get("completion", "")
+
+    last_chunk = Claude2StreamResponseItem(request_id, response_headers=response_headers_stream_json, duration=1.0, duration_api=2.0, request_json=request_json)
+    accesslog = last_chunk.to_accesslog(chunks, AccessLog)
+
+    assert accesslog.request_id == request_id
+    assert isinstance(accesslog.created_at, datetime)
+    assert accesslog.direction == "response"
+    assert accesslog.content == content
+    assert accesslog.function_call is None
+    assert accesslog.tool_calls is None
+    assert accesslog.raw_body == json.dumps(chunks_json, ensure_ascii=False)
+    assert accesslog.raw_headers == json.dumps(response_headers_stream_json, ensure_ascii=False)
+    assert accesslog.model == "anthropic.claude-v2"
+    assert accesslog.prompt_tokens > 0
+    assert accesslog.completion_tokens > 0
+    assert accesslog.request_time == last_chunk.duration
+    assert accesslog.request_time_api == last_chunk.duration_api
+
+
+@pytest.fixture
+def worker():
+    return AccessLogWorker(connection_str=DB_CONNECTION_STR)
+
+@pytest.fixture
+def claude2_proxy(worker):
+    return Claude2Proxy(access_logger_queue=worker.queue_client)
+
+@pytest.fixture
+def db(worker):
+    return worker.get_session()
+
+@pytest.fixture
+def boto3_client():
+    session = boto3.Session(
+        aws_access_key_id="aws_access_key_id",
+        aws_secret_access_key="aws_secret_access_key",
+    )
+
+    return session.client(
+        service_name="bedrock-runtime", 
+        region_name="private",
+        endpoint_url="http://127.0.0.1:8000",
+    )
+
+@pytest.mark.asyncio
+async def test_request_filter_overwrite(claude2_proxy, request_json, request_headers):
+    request_id = str(uuid4())
+    request_json["model"] = "anthropic.claude-v3"
+
+    claude2_proxy.add_filter(OverwriteFilter())
+    await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+
+    assert request_json["model"] == "anthropic.claude-v100-twinturbo"
+
+
+@pytest.mark.asyncio
+async def test_request_filter_valuereturn(claude2_proxy, request_json, request_headers):
+    request_id = str(uuid4())
+
+    claude2_proxy.add_filter(ValueReturnFilter())
+
+    ret = await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+    assert json.loads(ret.body.decode())["completion"] == "user is required"
+
+    request_json["user"] = "uezo"
+    ret = await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+    assert json.loads(ret.body.decode())["completion"] == "you can't use this service"
+
+    request_json["user"] = "unagi"
+    ret = await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+    assert ret == request_json
+
+
+@pytest.mark.asyncio
+async def test_request_filter_valuereturn_stream(claude2_proxy, request_json, request_headers):
+    request_id = str(uuid4())
+
+    claude2_proxy.add_filter(ValueReturnFilter())
+
+    ret = await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+    assert json.loads(ret.body.decode())["completion"] == "user is required"
+
+    request_json["user"] = "uezo"
+    ret = await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+    assert json.loads(ret.body.decode())["completion"] == "you can't use this service"
+
+    request_json["user"] = "unagi"
+    ret = await claude2_proxy.filter_request(request_id, request_json, request_headers, False)
+    assert ret == request_json
+
+
+@pytest.mark.asyncio
+async def test_response_filter_valuereturn(claude2_proxy, response_json):
+    request_id = str(uuid4())
+
+    claude2_proxy.add_filter(OverwriteResponseFilter())
+
+    ret = await claude2_proxy.filter_response(request_id, response_json)
+
+    assert ret["completion"] == "Overwrite in filter"
+
+
+def test_post_content(prompt, request_json, request_headers, boto3_client, db):
+    body = json.dumps(request_json)
+    response = boto3_client.invoke_model(
+        modelId="anthropic.claude-v2",
+        body=body
+    )
+
+    comp_resp = response["body"]._raw_stream.json()
+    headers = response["ResponseMetadata"]["HTTPHeaders"]
+    request_id = headers.get("x-aiproxy-request-id")
+
+    assert request_id is not None
+    assert "うなぎ" in comp_resp["completion"]
+
+    # Wait for processing queued items
+    sleep(2.0)
+
+    db_request = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "request").first()
+    db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "response").first()
+
+    assert db_request.content == prompt
+    assert db_resonse.content == comp_resp["completion"]
+
+
+def test_post_content_apierror(prompt, request_json, request_headers, boto3_client, db):
+    with pytest.raises(ClientError) as apisterr:
+        request_json["extrakey"] = "extravalue"
+        body = json.dumps(request_json)
+        boto3_client.invoke_model(
+            modelId="anthropic.claude-v2",
+            body=body
+        )
+    
+    api_resp = apisterr.value.response
+
+    assert api_resp["ResponseMetadata"]["HTTPStatusCode"] == 400
+
+    headers = api_resp["ResponseMetadata"]["HTTPHeaders"]
+    request_id = headers.get("x-aiproxy-request-id")
+
+    assert request_id is not None
+
+    # Wait for processing queued items
+    sleep(2.0)
+
+    db_request = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "request").first()
+    db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "error").first()
+
+    assert db_request.content == prompt
+    assert str(api_resp["ResponseMetadata"]["HTTPStatusCode"]) in db_resonse.content
+
+
+def test_post_content_stream(prompt, request_json, request_headers, boto3_client, db):
+    body = json.dumps(request_json)
+    response = boto3_client.invoke_model_with_response_stream(
+        modelId="anthropic.claude-v2",
+        body=body
+    )
+
+    headers = response["ResponseMetadata"]["HTTPHeaders"]
+    request_id = headers.get("x-aiproxy-request-id")
+    assert request_id is not None
+
+    content = ""
+    stream = response.get("body")
+    if stream:
+        for event in stream:
+            chunk = event.get("chunk")
+            if chunk:
+                content += json.loads(chunk.get("bytes").decode())["completion"]
+
+    # Wait for processing queued items
+    sleep(2.0)
+
+    db_request = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "request").first()
+    db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "response").first()
+
+    assert db_request.content == prompt
+    assert db_resonse.content == content
+
+
+def test_post_content_stream_apierror(prompt, request_json, request_headers, boto3_client, db):
+    with pytest.raises(ClientError) as apisterr:
+        request_json["extrakey"] = "extravalue"
+        body = json.dumps(request_json)
+        boto3_client.invoke_model_with_response_stream(
+            modelId="anthropic.claude-v2",
+            body=body
+        )
+    
+    api_resp = apisterr.value.response
+
+    assert api_resp["ResponseMetadata"]["HTTPStatusCode"] == 400
+
+    headers = api_resp["ResponseMetadata"]["HTTPHeaders"]
+    request_id = headers.get("x-aiproxy-request-id")
+
+    assert request_id is not None
+
+    # Wait for processing queued items
+    sleep(2.0)
+
+    db_request = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "request").first()
+    db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "error").first()
+
+    assert db_request.content == prompt
+    assert "x-amzn-errortype" in json.loads(db_resonse.raw_headers)


### PR DESCRIPTION
To use Claude2 on AWS Bedrock, instantiate `Claude2Proxy` and add route to it.

```python
from aiproxy.claude2 import Claude2Proxy
claude_proxy = Claude2Proxy(
    aws_access_key_id="YOUR_AWS_ACCESS_KEY_ID",
    aws_secret_access_key="YOUR_AWS_SECRET_ACCESS_KEY",
    region_name="your-bedrock-region",
    access_logger_queue=worker.queue_client
)
claude_proxy.add_route(app, "/model/anthropic.claude-v2")
```

Client side. We test API with boto3.

```python
import boto3
import json
# Make client with dummy creds
session = boto3.Session(aws_access_key_id="dummy", aws_secret_access_key="dummy",)
bedrock = session.client(service_name="bedrock-runtime", region_name="private", endpoint_url="http://127.0.0.1:8000")
# Call API
response = bedrock.invoke_model(
    modelId="anthropic.claude-v2",
    body=json.dumps({"prompt": "Human: What is the difference between eel (unagi) and conger eel (anago)?\nAssistant: ", "max_tokens_to_sample": 100})
)
# Show response
print(json.loads(response["body"].read()))
```
