### PR TITLE
Add temporary workaround for SQL Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ proxy = ChatGPTProxy(
 
 You can use other RDBMS that is supported by SQLAlchemy. You can use them by just changing connection string. (and, install client libraries required.)
 
-Example for PostgreSQL🐘
+#### Example for PostgreSQL🐘
 
 ```sh
 $ pip install psycopg2-binary
@@ -343,6 +343,22 @@ connection_str = f"postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{DATABASE}"
 worker = AccessLogWorker(connection_str=connection_str)
 ```
 
+#### Example for SQL Server or Azure SQL Database
+
+This is a temporary workaroud from AIProxy >= 0.3.6. Set `AIPROXY_USE_NVARCHAR=1` to use NVARCHAR internally.
+
+```sh
+$ export AIPROXY_USE_NVARCHAR=1
+```
+
+Install ODBC driver (version 18 in this example) and `pyodbc` then set connection string as follows:
+
+```python
+# connection_str = "sqlite:///aiproxy.db"
+connection_str = f"mssql+pyodbc:///?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=YOUR_SERVER;PORT=1433;DATABASE=YOUR_DB;UID=YOUR_UID;PWD=YOUR_PWD"
+
+worker = AccessLogWorker(connection_str=connection_str)
+```
 
 ### Restrictions
 

--- a/aiproxy/accesslog.py
+++ b/aiproxy/accesslog.py
@@ -2,17 +2,22 @@ from abc import abstractmethod
 from datetime import datetime
 import json
 import logging
+import os
 from time import sleep
 import traceback
-from sqlalchemy import Column, Integer, String, Float, DateTime, create_engine
+from sqlalchemy import Column, Integer, String, NVARCHAR, Float, DateTime, create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base, declared_attr, Session
 from .queueclient import DefaultQueueClient, QueueItemBase, QueueClientBase
 
 
 logger = logging.getLogger(__name__)
 
+_use_nvarchar = True if os.environ.get("AIPROXY_USE_NVARCHAR") == "1" else False
+
 
 class _AccessLogBase:
+    use_nvarchar = _use_nvarchar
+
     @declared_attr
     def __tablename__(cls):
         return cls.__name__.lower()
@@ -39,23 +44,23 @@ class _AccessLogBase:
 
     @declared_attr
     def content(cls):
-        return Column(String)
+        return Column(NVARCHAR) if cls.use_nvarchar else Column(String)
 
     @declared_attr
     def function_call(cls):
-        return Column(String)
+        return Column(NVARCHAR) if cls.use_nvarchar else Column(String)
 
     @declared_attr
     def tool_calls(cls):
-        return Column(String)
+        return Column(NVARCHAR) if cls.use_nvarchar else Column(String)
 
     @declared_attr
     def raw_body(cls):
-        return Column(String)
+        return Column(NVARCHAR) if cls.use_nvarchar else Column(String)
 
     @declared_attr
     def raw_headers(cls):
-        return Column(String)
+        return Column(NVARCHAR) if cls.use_nvarchar else Column(String)
 
     @declared_attr
     def model(cls):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="aiproxy-python",
-    version="0.3.4",
+    version="0.3.6",
     url="https://github.com/uezo/aiproxy",
     author="uezo",
     author_email="uezo@uezo.net",


### PR DESCRIPTION
This is a temporary workaroud from AIProxy >= 0.3.6. Set `AIPROXY_USE_NVARCHAR=1` to use NVARCHAR internally.

```sh
$ export AIPROXY_USE_NVARCHAR=1
```

Install ODBC driver (version 18 in this example) and `pyodbc` then set connection string as follows:

```python
# connection_str = "sqlite:///aiproxy.db"
connection_str = f"mssql+pyodbc:///?odbc_connect=DRIVER={ODBC Driver 18 for SQL Server};SERVER=YOUR_SERVER;PORT=1433;DATABASE=YOUR_DB;UID=YOUR_UID;PWD=YOUR_PWD"

worker = AccessLogWorker(connection_str=connection_str)
```