### PR TITLE
Switch from official API client to httpx

### DIFF
--- a/aiproxy/chatgpt.py
+++ b/aiproxy/chatgpt.py
@@ -1,26 +1,18 @@
 from datetime import datetime
 import json
 import logging
-import os
-import time
-import traceback
-from typing import List, Union, AsyncGenerator
-from uuid import uuid4
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-from sse_starlette.sse import EventSourceResponse, AsyncContentStream
-from openai import AsyncClient, APIStatusError, APIResponseValidationError, APIError, OpenAIError
-from openai.types.chat import ChatCompletion
+from typing import List
 import tiktoken
-from .proxy import ProxyBase, RequestFilterBase, ResponseFilterBase, RequestFilterException, ResponseFilterException
-from .accesslog import _AccessLogBase, RequestItemBase, ResponseItemBase, StreamChunkItemBase, ErrorItemBase
+from fastapi import Request
+from .proxy import RequestFilterBase, ResponseFilterBase
+from .httpx_proxy import HTTPXProxy, SessionInfo, SessionRequestItemBase, SessionResponseItemBase, SessionStreamChunkItemBase, SessionErrorItemBase
+from .accesslog import _AccessLogBase
 from .queueclient import QueueClientBase
-
 
 logger = logging.getLogger(__name__)
 
 
-class ChatGPTRequestItem(RequestItemBase):
+class ChatGPTRequestItem(SessionRequestItemBase):
     def to_accesslog(self, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
         request_headers_copy = self.request_headers.copy()
         if auth := request_headers_copy.get("authorization"):
@@ -48,7 +40,7 @@ class ChatGPTRequestItem(RequestItemBase):
         return accesslog
 
 
-class ChatGPTResponseItem(ResponseItemBase):
+class ChatGPTResponseItem(SessionResponseItemBase):
     def to_accesslog(self, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
         content=self.response_json["choices"][0]["message"].get("content")
         function_call=self.response_json["choices"][0]["message"].get("function_call")
@@ -123,24 +115,34 @@ def count_request_token(request_json: dict):
     return token_count
 
 
-class ChatGPTStreamResponseItem(StreamChunkItemBase):
-    def to_accesslog(self, chunks: list, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
-        chunk_jsons = []
-        response_content = ""
+class ChatGPTStreamResponseItem(SessionStreamChunkItemBase):
+    def to_accesslog(self, accesslog_cls: _AccessLogBase) -> _AccessLogBase:
+        response_text = ""
+        model = ""
         function_call = None
         tool_calls = None
         prompt_tokens = 0
         completion_tokens = 0
 
         # Parse info from chunks
+        chunks = self.response_content.split("\n\n")
         for chunk in chunks:
-            chunk_jsons.append(chunk.chunk_json)
+            chunk_strip = chunk.strip()
+            if not chunk_strip.startswith("data:"):
+                continue    # Skip invalid data
+            if chunk_strip.endswith("[DONE]"):
+                break       # Break when [DONE]
 
-            if len(chunk.chunk_json["choices"]) == 0:
+            chunk_json = json.loads(chunk_strip[5:])
+
+            if len(chunk_json["choices"]) == 0:
                 # Azure returns the first delta with empty choices
                 continue
+            
+            if not model and "model" in chunk_json:
+                model = chunk_json.get("model")
 
-            delta = chunk.chunk_json["choices"][0]["delta"]
+            delta = chunk_json["choices"][0]["delta"]
 
             # Make tool_calls
             if delta.get("tool_calls"):
@@ -169,7 +171,7 @@ class ChatGPTStreamResponseItem(StreamChunkItemBase):
 
             # Text content
             else:
-                response_content += delta.get("content") or ""
+                response_text += delta.get("content") or ""
         
         # Serialize
         function_call_str = json.dumps(function_call, ensure_ascii=False) if function_call is not None else None
@@ -177,26 +179,26 @@ class ChatGPTStreamResponseItem(StreamChunkItemBase):
         response_headers = json.dumps(dict(self.response_headers.items()), ensure_ascii=False) if self.response_headers is not None else None
 
         # Count tokens
-        prompt_tokens = count_request_token(self.request_json)
+        prompt_tokens = count_request_token(self.session.request_json)
 
         if tool_calls_str:
             completion_tokens = count_token(tool_calls_str)
         elif function_call_str:
             completion_tokens = count_token(function_call_str)
         else:
-            completion_tokens = count_token(response_content)
+            completion_tokens = count_token(response_text)
 
         return accesslog_cls(
             request_id=self.request_id,
             created_at=datetime.utcnow(),
             direction="response",
             status_code=self.status_code,
-            content=response_content,
+            content=response_text,
             function_call=function_call_str,
             tool_calls=tool_calls_str,
-            raw_body=json.dumps(chunk_jsons, ensure_ascii=False),
+            raw_body=self.response_content,
             raw_headers=response_headers,
-            model=chunk_jsons[0]["model"],
+            model=model,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             request_time=self.duration,
@@ -204,312 +206,86 @@ class ChatGPTStreamResponseItem(StreamChunkItemBase):
         )
 
 
-class ChatGPTErrorItem(ErrorItemBase):
+class ChatGPTErrorItem(SessionErrorItemBase):
     ...
 
 
 queue_item_types = [ChatGPTRequestItem, ChatGPTResponseItem, ChatGPTStreamResponseItem, ChatGPTErrorItem]
 
 
-# Reverse proxy application for ChatGPT
-class ChatGPTProxy(ProxyBase):
-    _empty_openai_api_key = "OPENAI_API_KEY_IS_NOT_SET"
-
+# Reverse proxy application for OpenAI ChatGPT API
+class ChatGPTProxy(HTTPXProxy):
     def __init__(
         self,
         *,
         api_key: str = None,
-        async_client: AsyncClient = None,
-        max_retries: int = 0,
-        timeout: float = 60.0,
+        timeout=60.0,
         request_filters: List[RequestFilterBase] = None,
         response_filters: List[ResponseFilterBase] = None,
         request_item_class: type = ChatGPTRequestItem,
         response_item_class: type = ChatGPTResponseItem,
         stream_response_item_class: type = ChatGPTStreamResponseItem,
         error_item_class: type = ChatGPTErrorItem,
-        access_logger_queue: QueueClientBase,
+        access_logger_queue: QueueClientBase
     ):
         super().__init__(
+            timeout=timeout,
             request_filters=request_filters,
             response_filters=response_filters,
+            request_item_class=request_item_class,
+            response_item_class=response_item_class,
+            stream_response_item_class=stream_response_item_class,
+            error_item_class=error_item_class,
             access_logger_queue=access_logger_queue
         )
 
-        # Log items
-        self.request_item_class = request_item_class
-        self.response_item_class = response_item_class
-        self.stream_response_item_class = stream_response_item_class
-        self.error_item_class = error_item_class
+        self.api_key = api_key
+        self.api_base_url = "https://api.openai.com/v1/chat/completions"
 
-        # ChatGPT client config
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY") or self._empty_openai_api_key
-        self.max_retries = max_retries
-        self.timeout = timeout
-        self.async_client = async_client
+    def text_to_response_json(self, text: str) -> dict:
+        return {
+            "id": "-",
+            "object": "chat.completion",
+            "created": int(datetime.utcnow().timestamp()),
+            "model": "request_filter",
+            "choices": [{
+                "index": 0,
+                "message": {
+                "role": "assistant",
+                "content": text,
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0
+            }
+        }
 
-    async def filter_request(self, request_id: str, request_json: dict, request_headers: dict) -> Union[dict, JSONResponse, EventSourceResponse]:
-        for f in self.request_filters:
-            if json_resp := await f.filter(request_id, request_json, request_headers):
-                # Return response if filter returns string
-                resp_for_log = {
-                    "id": "-",
-                    "choices": [{"message": {"role": "assistant", "content": json_resp}, "finish_reason": "stop", "index": 0}],
-                    "created": 0,
-                    "model": "request_filter",
-                    "object": "chat.completion",
-                    "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-                }
-                # Response log
-                self.access_logger_queue.put(self.response_item_class(
-                    request_id=request_id,
-                    response_json=resp_for_log,
-                    status_code=200
-                ))
+    def text_to_response_chunks(self, text: str) -> List[dict]:
+        first_chunk = {
+            "id": "-",
+            "choices": [{"delta": {"role": "assistant", "content": ""}, "finish_reason": None, "index": 0}],
+            "created": 0,
+            "model": "request_filter",
+            "object": "chat.completion",
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        }
+        last_chunk = {
+            "id": "-",
+            "choices": [{"delta": {"content": text}, "finish_reason": "stop", "index": 0}],
+            "created": 0,
+            "model": "request_filter",
+            "object": "chat.completion",
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        }
+        return [first_chunk, last_chunk]
 
-                if request_json.get("stream"):
-                    # Stream
-                    async def filter_response_stream(content: str):
-                        # First delta
-                        resp = {
-                            "id": "-",
-                            "choices": [{"delta": {"role": "assistant", "content": ""}, "finish_reason": None, "index": 0}],
-                            "created": 0,
-                            "model": "request_filter",
-                            "object": "chat.completion",
-                            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-                        }
-                        yield json.dumps(resp)
-                        # Last delta
-                        resp["choices"][0] = {"delta": {"content": content}, "finish_reason": "stop", "index": 0}
-                        yield json.dumps(resp)
+    async def parse_request(self, fastapi_request: Request, session: SessionInfo):
+        await super().parse_request(fastapi_request, session)
+        session.stream = session.request_json.get("stream") is True
 
-                    return self.return_response_with_headers(EventSourceResponse(
-                        filter_response_stream(json_resp)
-                    ), request_id)
-
-                else:
-                    # Non-stream
-                    return self.return_response_with_headers(JSONResponse(resp_for_log), request_id)
-
-        return request_json
-
-    def get_client(self):
-        return self.async_client or AsyncClient(
-            api_key=self.api_key,
-            max_retries=self.max_retries,
-            timeout=self.timeout
-        )
-
-    async def filter_response(self, request_id: str, response: ChatCompletion) -> ChatCompletion:
-        response_json = response.model_dump()
-
-        for f in self.response_filters:
-            if json_resp := await f.filter(request_id, response_json):
-                return response.model_validate(json_resp)
-
-        return response.model_validate(response_json)
-
-    def return_response_with_headers(self, resp: JSONResponse, request_id: str):
-        self.add_response_headers(response=resp, request_id=request_id)
-        return resp
-
-    def add_route(self, app: FastAPI, base_url: str):
-        @app.post(base_url)
-        async def handle_request(request: Request):
-            request_id = str(uuid4())
-            async_client = None
-
-            try:
-                start_time = time.time()
-                request_json = await request.json()
-                request_headers = dict(request.headers.items())
-
-                # Log request
-                self.access_logger_queue.put(self.request_item_class(
-                    request_id=request_id,
-                    request_json=request_json,
-                    request_headers=request_headers
-                ))
-
-                # Filter request
-                request_json = await self.filter_request(request_id, request_json, request_headers)
-                if isinstance(request_json, JSONResponse) or isinstance(request_json, EventSourceResponse):
-                    return request_json
-
-                # Call API
-                async_client = self.get_client()
-                start_time_api = time.time()
-                if self.api_key != self._empty_openai_api_key:
-                    # Always use server api key if set to client
-                    raw_response = await async_client.chat.completions.with_raw_response.create(**request_json)
-                elif user_auth_header := request_headers.get("authorization"):  # Lower case from client.
-                    raw_response = await async_client.chat.completions.with_raw_response.create(
-                        **request_json, extra_headers={"Authorization": user_auth_header}   # Pascal to server
-                    )
-                else:
-                    # Call API anyway ;)
-                    raw_response = await async_client.chat.completions.with_raw_response.create(**request_json)
-
-                completion_response = raw_response.parse()
-                completion_response_headers = raw_response.headers
-                completion_status_code = raw_response.status_code
-                if "content-encoding" in completion_response_headers:
-                    completion_response_headers.pop("content-encoding") # Remove "br" that will be changed by this proxy
-
-                # Handling response from API
-                if request_json.get("stream"):
-                    async def process_stream(stream: AsyncContentStream) -> AsyncGenerator[str, None]:
-                        # Async content generator
-                        try:
-                            async for chunk in stream:
-                                self.access_logger_queue.put(self.stream_response_item_class(
-                                    request_id=request_id,
-                                    chunk_json=chunk.model_dump()
-                                ))
-                                if chunk:
-                                    yield chunk.model_dump_json()
-
-                        finally:
-                            # Close client after reading stream
-                            await async_client.close()
-
-                            # Response log
-                            now = time.time()
-                            self.access_logger_queue.put(self.stream_response_item_class(
-                                request_id=request_id,
-                                response_headers=completion_response_headers,
-                                duration=now - start_time,
-                                duration_api=now - start_time_api,
-                                request_json=request_json,
-                                status_code=completion_status_code
-                            ))
-
-                    return self.return_response_with_headers(EventSourceResponse(
-                        process_stream(completion_response),
-                        headers=completion_response_headers
-                    ), request_id)
-
-                else:
-                    # Close client imediately
-                    await async_client.close()
-
-                    duration_api = time.time() - start_time_api
-
-                    # Filter response
-                    completion_response = await self.filter_response(request_id, completion_response)
-
-                    # Response log
-                    self.access_logger_queue.put(self.response_item_class(
-                        request_id=request_id,
-                        response_json=completion_response.model_dump(),
-                        response_headers=completion_response_headers,
-                        duration=time.time() - start_time,
-                        duration_api=duration_api,
-                        status_code=completion_status_code
-                    ))
-
-                    return self.return_response_with_headers(JSONResponse(
-                        content=completion_response.model_dump(),
-                        headers=completion_response_headers
-                    ), request_id)
-
-            # Error handlers
-            except RequestFilterException as rfex:
-                logger.error(f"Request filter error: {rfex}\n{traceback.format_exc()}")
-
-                resp_json = {"error": {"message": rfex.message, "type": "request_filter_error", "param": None, "code": None}}
-
-                # Error log
-                self.access_logger_queue.put(self.error_item_class(
-                    request_id=request_id,
-                    exception=rfex,
-                    traceback_info=traceback.format_exc(),
-                    response_json=resp_json,
-                    status_code=rfex.status_code
-                ))
-
-                return self.return_response_with_headers(JSONResponse(resp_json, status_code=rfex.status_code), request_id)
-
-            except ResponseFilterException as rfex:
-                logger.error(f"Response filter error: {rfex}\n{traceback.format_exc()}")
-
-                resp_json = {"error": {"message": rfex.message, "type": "response_filter_error", "param": None, "code": None}}
-
-                # Error log
-                self.access_logger_queue.put(self.error_item_class(
-                    request_id=request_id,
-                    exception=rfex,
-                    traceback_info=traceback.format_exc(),
-                    response_json=resp_json,
-                    status_code=rfex.status_code
-                ))
-
-                return self.return_response_with_headers(JSONResponse(resp_json, status_code=rfex.status_code), request_id)
-
-            except (APIStatusError, APIResponseValidationError) as status_err:
-                logger.error(f"APIStatusError from ChatGPT: {status_err}\n{traceback.format_exc()}")
-
-                # Error log
-                try:
-                    resp_json = status_err.response.json()
-                except:
-                    resp_json = str(status_err.response.content)
-
-                self.access_logger_queue.put(self.error_item_class(
-                    request_id=request_id,
-                    exception=status_err,
-                    traceback_info=traceback.format_exc(),
-                    response_json=resp_json,
-                    status_code=status_err.status_code
-                ))
-
-                return self.return_response_with_headers(JSONResponse(resp_json, status_code=status_err.status_code), request_id)
-
-            except APIError as api_err:
-                logger.error(f"APIError from ChatGPT: {api_err}\n{traceback.format_exc()}")
-
-                resp_json = {"error": {"message": api_err.message, "type": api_err.type, "param": api_err.param, "code": api_err.code}}
-
-                # Error log
-                self.access_logger_queue.put(self.error_item_class(
-                    request_id=request_id,
-                    exception=api_err,
-                    traceback_info=traceback.format_exc(),
-                    response_json=resp_json,
-                    status_code=502
-                ))
-
-                return self.return_response_with_headers(JSONResponse(resp_json, status_code=502), request_id)
-
-            except OpenAIError as oai_err:
-                logger.error(f"OpenAIError: {oai_err}\n{traceback.format_exc()}")
-
-                resp_json = {"error": {"message": str(oai_err), "type": "openai_error", "param": None, "code": None}}
-
-                # Error log
-                self.access_logger_queue.put(self.error_item_class(
-                    request_id=request_id,
-                    exception=oai_err,
-                    traceback_info=traceback.format_exc(),
-                    response_json=resp_json,
-                    status_code=502
-                ))
-
-                return self.return_response_with_headers(JSONResponse(resp_json, status_code=502), request_id)
-
-            except Exception as ex:
-                logger.error(f"Error at server: {ex}\n{traceback.format_exc()}")
-
-                resp_json = {"error": {"message": "Proxy error", "type": "proxy_error", "param": None, "code": None}}
-
-                # Error log
-                self.access_logger_queue.put(self.error_item_class(
-                    request_id=request_id,
-                    exception=ex,
-                    traceback_info=traceback.format_exc(),
-                    response_json=resp_json,
-                    status_code=502
-                ))
-
-                return self.return_response_with_headers(JSONResponse(resp_json, status_code=502), request_id)
+    def prepare_httpx_request_headers(self, session: SessionInfo):
+        super().prepare_httpx_request_headers(session)
+        session.request_headers["authorization"] = f"Bearer {self.api_key}"

--- a/aiproxy/httpx_proxy.py
+++ b/aiproxy/httpx_proxy.py
@@ -1,0 +1,375 @@
+import json
+import logging
+import time
+import traceback
+from typing import List, Union
+from uuid import uuid4
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
+import httpx
+from aiproxy.proxy import ProxyBase, RequestFilterBase, ResponseFilterBase, RequestFilterException, ResponseFilterException
+from aiproxy.queueclient import QueueClientBase
+from aiproxy.accesslog import RequestItemBase, ResponseItemBase, StreamChunkItemBase, ErrorItemBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class SessionInfo:
+    def __init__(self):
+        # Request
+        self.request_id = str(uuid4())
+        self.request_json = None
+        self.request_headers = None
+        self.request_url = None
+        self.stream = False
+
+        # Response
+        self.response_json = None
+        self.response_body = None
+        self.response_headers = None
+        self.duration = 0.0
+        self.duration_api = 0.0
+        self.status_code = 0
+
+        self.extra_info = {}
+
+        # Status
+        self.start_time = time.time()
+        self.start_time_api = self.start_time
+
+
+class SessionRequestItemBase(RequestItemBase):
+    def __init__(self, request_id: str, request_json: dict, request_headers: dict):
+        super().__init__(request_id, request_json, request_headers)
+        self.session: SessionInfo = None
+
+    @classmethod
+    def from_session(cls, session: SessionInfo):
+        item = cls(session.request_id, session.request_json, session.request_headers)
+        item.session = session
+        return item
+
+
+class SessionResponseItemBase(ResponseItemBase):
+    def __init__(self, request_id: str, response_json: dict, response_headers: dict = None, duration: float = 0, duration_api: float = 0, status_code: int = 0) -> None:
+        super().__init__(request_id, response_json, response_headers, duration, duration_api, status_code)
+        self.session: SessionInfo = None
+
+    @classmethod
+    def from_session(cls, session: SessionInfo):
+        item = cls(session.request_id, session.response_json, session.response_headers, session.duration, session.duration_api, session.status_code)
+        item.session = session
+        return item
+
+
+class SessionStreamChunkItemBase(StreamChunkItemBase):
+    def __init__(self, request_id: str, response_content: str = None, response_headers: dict = None, duration: float = 0, duration_api: float = 0, status_code: int = 0) -> None:
+        super().__init__(request_id, response_content, response_headers, duration, duration_api, status_code)
+        self.session: SessionInfo = None
+
+    @classmethod
+    def from_session(cls, session: SessionInfo):
+        item = cls(session.request_id, session.response_body, session.response_headers, session.duration, session.duration_api, session.status_code)
+        item.session = session
+        return item
+
+
+class SessionErrorItemBase(ErrorItemBase):
+    def __init__(self, request_id: str, exception: Exception, traceback_info: str, response_json: dict = None, response_headers: dict = None, status_code: int = 0) -> None:
+        super().__init__(request_id, exception, traceback_info, response_json, response_headers, status_code)
+        self.session: SessionInfo = None
+
+    @classmethod
+    def from_session(cls, session: SessionInfo, exception: Exception, traceback_info: str):
+        item = cls(session.request_id, exception, traceback_info, session.response_json, session.response_headers, session.status_code)
+        item.session = session
+        return item
+
+
+# HTTPX-based reverse proxy application
+class HTTPXProxy(ProxyBase):
+    def __init__(
+        self,
+        *,
+        timeout=60.0,
+        request_filters: List[RequestFilterBase] = None,
+        response_filters: List[ResponseFilterBase] = None,
+        request_item_class: type = None,
+        response_item_class: type = None,
+        stream_response_item_class: type = None,
+        error_item_class: type = None,
+        access_logger_queue: QueueClientBase
+    ):
+        super().__init__(
+            request_filters=request_filters,
+            response_filters=response_filters,
+            access_logger_queue=access_logger_queue
+        )
+
+        self.timeout = timeout
+
+        # Log items
+        self.request_item_class: SessionRequestItemBase = request_item_class
+        self.response_item_class: SessionResponseItemBase = response_item_class
+        self.stream_response_item_class: SessionStreamChunkItemBase = stream_response_item_class
+        self.error_item_class: SessionErrorItemBase = error_item_class
+
+        self.api_base_url = "empty_url"
+
+    # Filter
+    def text_to_response_json(self, text: str) -> dict:
+        raise NotImplementedError("'text_to_response_json' must be implemented to use request filter")
+
+    def text_to_response_chunks(self, text: str) -> list[dict]:
+        raise NotImplementedError("'text_to_response_chunks' must be implemented to use request filter")
+
+    async def filter_request(self, session: SessionInfo) -> Union[None, JSONResponse, EventSourceResponse]:
+        for f in self.request_filters:
+            if completion_content := await f.filter(session.request_id, session.request_json, session.request_headers):
+                # Make JsonResponse when filter returns content
+                session.response_json = self.text_to_response_json(completion_content)
+                json_response = JSONResponse(session.response_json)
+                self.add_response_headers(json_response, session.request_id)
+                session.response_headers = dict(json_response.headers)
+
+                # Response log
+                self.access_logger_queue.put(
+                    self.response_item_class.from_session(session=session)
+                )
+
+                # Return stream/non-stream response
+                if session.stream:
+                    async def filter_response_stream(deltas: list[dict]):
+                        async for d in deltas:
+                            yield d
+
+                    sse_resp = EventSourceResponse(
+                        filter_response_stream(self.text_to_response_chunks(completion_content))
+                    )
+                    self.add_response_headers(sse_resp, session.request_id)
+                    return sse_resp
+
+                else:
+                    return json_response
+
+        return None
+
+    async def filter_response(self, request_id: str, response_json: dict) -> dict:
+        for f in self.response_filters:
+            if immediately_return_json_resp := await f.filter(request_id, response_json):
+                return immediately_return_json_resp
+
+        return response_json
+
+    # Parser and preparation for request and response
+    async def parse_request(self, fastapi_request: Request, session: SessionInfo):
+        session.request_json = await fastapi_request.json()
+        session.request_headers = dict(fastapi_request.headers.items())
+        session.request_url = str(fastapi_request.url)
+
+    async def parse_response(self, httpx_response: httpx.Response, session: SessionInfo):
+        session.response_headers = dict(httpx_response.headers)
+        session.status_code = httpx_response.status_code
+        if not session.stream:
+            session.response_json = httpx_response.json()
+            session.duration_api = time.time() - session.start_time_api
+
+    def prepare_httpx_request_headers(self, session: SessionInfo):
+        if session.request_headers.get("host"):
+            del session.request_headers["host"]
+        if session.request_headers.get("content-length"):
+            del session.request_headers["content-length"]
+
+    def prepare_httpx_response_headers(self, session: SessionInfo):
+        if session.response_headers.get("date"):
+            del session.response_headers["date"]
+        if session.response_headers.get("content-length"):
+            del session.response_headers["content-length"]
+        if session.response_headers.get("content-encoding"):
+            del session.response_headers["content-encoding"]
+        if session.response_headers.get("cache-control"):
+            del session.response_headers["cache-control"]
+
+        session.response_headers["X-AIProxy-Request-Id"] = session.request_id
+
+    def make_url(self, session: SessionInfo):
+        return self.api_base_url
+
+    # Make responses
+    async def make_json_response(self, async_client: httpx.AsyncClient, session: SessionInfo):
+        try:
+            # Filter response
+            original_response_json = session.response_json.copy()
+            filtered_response_json = await self.filter_response(session.request_id, session.response_json)
+            session.response_json = original_response_json if original_response_json == filtered_response_json else filtered_response_json
+
+            # Make JSON response
+            json_response = JSONResponse(
+                session.response_json,
+                session.status_code,
+                session.response_headers
+            )
+
+            # Response log
+            session.duration = time.time() - session.start_time
+            self.access_logger_queue.put(
+                self.response_item_class.from_session(session=session)
+            )
+
+            return json_response
+
+        finally:
+            await async_client.aclose()
+
+    def make_stream_response(self, async_client: httpx.AsyncClient, stream_response: httpx.Response, session: SessionInfo):
+        async def process_stream():
+            session.response_body = ""
+            try:
+                # Yield chunked responses
+                chunk_buffer = ""
+                async for b in stream_response.aiter_raw():
+                    chunk = b.decode("utf-8")
+                    session.response_body += chunk
+                    if chunk.endswith("\n\n"):
+                        chunk = (chunk_buffer + chunk).strip().split("\n\n")
+                        chunk_buffer = ""
+                    else:
+                        chunk_buffer += chunk
+                        continue
+
+                    for ev in chunk:
+                        event_type = ""
+                        datas = []
+                        for line in ev.split("\n"):
+                            if line.startswith("event:"):
+                                event_type = line[6:].strip()
+                            elif line.startswith("data:"):
+                                datas.append(line[5:].strip())
+
+                        yield {"event": event_type, "data": "\n".join(datas)}
+            
+            finally:
+                # Make response log
+                try:
+                    now = time.time()
+                    session.duration = now - session.start_time
+                    session.duration_api = now - session.start_time_api
+                    self.access_logger_queue.put(
+                        self.stream_response_item_class.from_session(session)
+                    )
+
+                except Exception as ex:
+                    logger.error(f"Failed in making log items: {ex}\n{traceback.format_exc()}")
+                    logger.error(f"response_content: {session.response_body}")
+                
+                finally:
+                    await async_client.aclose()
+
+        return EventSourceResponse(
+            process_stream(),
+            status_code=session.status_code,
+            headers=session.response_headers
+        )
+
+    def make_error_response(self, session: SessionInfo, status_code: int, ex: Exception, error_type: str, **kwargs) -> JSONResponse:
+        # Make error response
+        resp_json = {"error": {"message": str(ex), "type": error_type}}
+        json_response = JSONResponse(resp_json, status_code=status_code)
+        self.add_response_headers(json_response, session.request_id)
+
+        # Error log
+        self.access_logger_queue.put(self.error_item_class.from_session(
+            session=session,
+            exception=ex,
+            traceback_info=traceback.format_exc()
+        ))
+
+        return json_response
+
+    # Request handler
+    def add_route(self, app: FastAPI, base_url: str):
+        @app.post(base_url)
+        async def handle_request(request: Request):
+            session = SessionInfo()
+
+            try:
+                await self.parse_request(request, session)
+                # Log request
+                self.access_logger_queue.put(self.request_item_class.from_session(session))
+
+                # Filter request
+                if filtered_response := await self.filter_request(session):
+                    return filtered_response
+
+                session.start_time_api = time.time()
+
+                # Call API and handling response from API
+                async_client = httpx.AsyncClient(timeout=self.timeout)
+                try:
+                    self.prepare_httpx_request_headers(session)
+                    httpx_request = httpx.Request(method="POST", url=self.make_url(session), headers=session.request_headers, json=session.request_json)
+                    httpx_response = await async_client.send(request=httpx_request, stream=session.stream)
+                    await self.parse_response(httpx_response, session)
+                    self.prepare_httpx_response_headers(session)
+                    httpx_response.raise_for_status()
+                except Exception as ex:
+                    await async_client.aclose()
+                    raise ex
+
+                if session.stream:
+                    return self.make_stream_response(
+                        async_client,
+                        httpx_response,
+                        session
+                    )
+                else:
+                    return await self.make_json_response(
+                        async_client,
+                        session
+                    )
+
+            # Error handlers
+            except RequestFilterException as rfex:
+                logger.error(f"Request filter error: {rfex}\n{traceback.format_exc()}")
+                return self.make_error_response(session, rfex.status_code, rfex, "request_filter_error")
+
+            except ResponseFilterException as rfex:
+                logger.error(f"Response filter error: {rfex}\n{traceback.format_exc()}")
+                return self.make_error_response(session, rfex.status_code, rfex, "response_filter_error")
+
+            except httpx.HTTPStatusError as htex:
+                logger.error(f"Error at server: {htex}\n{traceback.format_exc()}")
+
+                # Error log
+                try:
+                    resp_json = htex.response.json()
+                except:
+                    try:
+                        content = await htex.response.aread()
+                        if isinstance(content, bytes):
+                            content = content.decode("utf-8")
+                        else:
+                            content = str(content)
+                        resp_json = json.loads(content)
+                    except:
+                        resp_json = {"type": "error", "error": {"type": "http_error", "message": "Failed in parsing error response."}}
+
+                self.prepare_httpx_response_headers(session)
+
+                self.access_logger_queue.put(self.error_item_class.from_session(
+                    session=session,
+                    exception=htex,
+                    traceback_info=traceback.format_exc()
+                ))
+
+                return JSONResponse(
+                    resp_json,
+                    status_code=htex.response.status_code,
+                    headers=session.response_headers
+                )
+
+            except Exception as ex:
+                logger.error(f"Error at server: {ex}\n{traceback.format_exc()}")
+                return self.make_error_response(session, 502, ex, "proxy_error")

--- a/aiproxy/queueclient.py
+++ b/aiproxy/queueclient.py
@@ -5,23 +5,7 @@ from typing import Iterator
 
 
 class QueueItemBase(ABC):
-    def to_dict(self) -> dict:
-        d = self.__dict__
-        d["type"] = self.__class__.__name__
-        return d
-
-    def to_json(self) -> str:
-        return json.dumps(self.to_dict())
-
-    @classmethod
-    def from_dict(cls, d: dict):
-        _d = d.copy()
-        del _d["type"]
-        return cls(**_d)
-
-    @classmethod
-    def from_json(cls, json_str: str):
-        return cls.from_dict(json.loads(json_str))
+    ...
 
 
 class QueueClientBase(ABC):

--- a/tests/test_chatgpt.py
+++ b/tests/test_chatgpt.py
@@ -1,7 +1,6 @@
 import pytest
 from datetime import datetime
 import json
-import os
 from time import sleep
 from typing import Union
 from uuid import uuid4
@@ -14,14 +13,13 @@ from aiproxy import (
     AccessLog,
     RequestFilterBase,
     ResponseFilterBase,
-    ChatGPTProxy,
     AccessLogBase
 )
 from aiproxy.accesslog import AccessLogWorker, _AccessLogBase
-from aiproxy.chatgpt import ChatGPTRequestItem, ChatGPTResponseItem, ChatGPTStreamResponseItem
+from aiproxy.httpx_proxy import SessionInfo
+from aiproxy.chatgpt import ChatGPTProxy, ChatGPTRequestItem, ChatGPTResponseItem, ChatGPTStreamResponseItem
 
 sqlite_conn_str = "sqlite:///aiproxy_test.db"
-postgresql_conn_str = f"postgresql://{os.getenv('PSQL_USER')}:{os.getenv('PSQL_PASSWORD')}@{os.getenv('PSQL_HOST')}:{os.getenv('PSQL_PORT')}/{os.getenv('PSQL_DATABASE')}"
 
 DB_CONNECTION_STR = sqlite_conn_str
 
@@ -145,1855 +143,124 @@ def response_headers():
     return {"x-aiproxy-request-id": "test-id"}
 
 @pytest.fixture
-def chunks_json():
-    return [
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "",
-                        "function_call": None,
-                        "role": "assistant",
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u7533",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3057",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u8a33",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3042\u308a",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u307e",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u305b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3093",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u304c",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3001",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u6771",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u4eac",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3068",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u540d",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u53e4",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5c4b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u306e",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5929",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u6c17",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u60c5",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5831",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3092",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u63d0",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u4f9b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3059\u308b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3053",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3068",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u306f",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3067",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u304d",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u307e",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u305b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3093",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3002",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5929",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u6c17",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u306b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u95a2",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3059\u308b",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u60c5",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5831",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u306f",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3001",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5929",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5019",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u4e88",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5831",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u30b5",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u30a4\u30c8",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3084",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5929",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u6c17",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u30a2",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u30d7",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u30ea",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3092",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3054",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u5229",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u7528",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u304f\u3060\u3055\u3044",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": "\u3002",
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzBaWVmpPZZJFdxZgynVwZMATday",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": "stop",
-                    "index": 0
-                }
-            ],
-            "created": 1701680746,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        }
-    ]
+def chunked_content():
+    return """
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"は"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"い"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"、"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"お"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"し"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"ゃ"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"べ"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"り"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"で"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"き"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"ます"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"！"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"何"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"を"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"お"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"話"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"し"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"し"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"ま"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"し"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"ょ"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"う"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"か"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"content":"？"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9JgLISX5sX016TyYaFOHshbBHQQfx","object":"chat.completion.chunk","created":1714478024,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+data: [DONE]
+"""
 
 @pytest.fixture
-def chunks_function():
-    return [
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "",
-                            "name": "get_weather"
-                        },
-                        "role": "assistant",
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "{\n",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": " ",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": " \"",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "location",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "\":",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": " \"",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "\u6771",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "\u4eac",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "\"\n",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": {
-                            "arguments": "}",
-                            "name": None
-                        },
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        },
-        {
-            "id": "chatcmpl-8RzHboLVZGBoFMc5gEGrMdcGHGPWs",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": "stop",
-                    "index": 0
-                }
-            ],
-            "created": 1701681119,
-            "model": "gpt-3.5-turbo-0613",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": None
-        }
-    ]
+def chunked_function():
+    return """
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"function_call":{"name":"get_weather","arguments":""}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"{\\""}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"location"}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"\\":\\""}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"名"}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"古"}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"屋"}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"function_call":{"arguments":"\\"}"}},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jh2AEqsFhgxJODlR9mjFILdXhCgZ","object":"chat.completion.chunk","created":1714480682,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"function_call"}]}
+
+data: [DONE]
+"""
 
 @pytest.fixture
-def chunks_tools():
-    return [
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": "assistant",
-                        "tool_calls": None
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": "call_vCJBXdx4kkyl16bIBy6i3SwD",
-                                "function": {
-                                    "arguments": "",
-                                    "name": "get_weather"
-                                },
-                                "type": "function"
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": None,
-                                "function": {
-                                    "arguments": "{\"lo",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": None,
-                                "function": {
-                                    "arguments": "catio",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": None,
-                                "function": {
-                                    "arguments": "n\": \"T",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": None,
-                                "function": {
-                                    "arguments": "okyo",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": None,
-                                "function": {
-                                    "arguments": "\"}",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 1,
-                                "id": "call_2pt8XB57mFTaij7CSeIVQm4j",
-                                "function": {
-                                    "arguments": "",
-                                    "name": "get_weather"
-                                },
-                                "type": "function"
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 1,
-                                "id": None,
-                                "function": {
-                                    "arguments": "{\"lo",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 1,
-                                "id": None,
-                                "function": {
-                                    "arguments": "catio",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 1,
-                                "id": None,
-                                "function": {
-                                    "arguments": "n\": \"N",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 1,
-                                "id": None,
-                                "function": {
-                                    "arguments": "agoy",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": [
-                            {
-                                "index": 1,
-                                "id": None,
-                                "function": {
-                                    "arguments": "a\"}",
-                                    "name": None
-                                },
-                                "type": None
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        },
-        {
-            "id": "chatcmpl-8RzQ18VWw1jxIzcFXGdGKrKusELgD",
-            "choices": [
-                {
-                    "delta": {
-                        "content": None,
-                        "function_call": None,
-                        "role": None,
-                        "tool_calls": None
-                    },
-                    "finish_reason": "tool_calls",
-                    "index": 0
-                }
-            ],
-            "created": 1701681641,
-            "model": "gpt-3.5-turbo-1106",
-            "object": "chat.completion.chunk",
-            "system_fingerprint": "fp_eeff13170a"
-        }
-    ]
+def chunked_tools():
+    return """
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_uIfE0D0tMU4p2vKusFbiU1OR","type":"function","function":{"name":"get_weather","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\""}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\""}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"名"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"古"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"屋"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"}"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9Jij02QHWARdjqLLfZgv3B2RzkC1z","object":"chat.completion.chunk","created":1714487182,"model":"gpt-3.5-turbo-0125","system_fingerprint":"fp_3b956da36b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+"""
 
 
 def test_request_item_to_accesslog(messages, request_json, request_headers, functions, tools):
-    request_id = str(uuid4())
     request_json["functions"] = functions
     request_json["tools"] = tools
-    item = ChatGPTRequestItem(request_id, request_json, request_headers)
 
+    session = SessionInfo()
+    session.request_json = request_json
+    session.request_headers = request_headers
+
+    item = ChatGPTRequestItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "request"
     assert accesslog.content == messages[-1]["content"]
@@ -2005,16 +272,19 @@ def test_request_item_to_accesslog(messages, request_json, request_headers, func
 
 
 def test_request_item_to_accesslog_array_content_textonly(messages, request_json, request_headers, functions, tools):
-    request_id = str(uuid4())
     request_json["functions"] = functions
     request_json["tools"] = tools
     text_content = request_json["messages"][0]["content"]
     request_json["messages"][0]["content"] = [{"type": "text", "text": text_content}]
-    item = ChatGPTRequestItem(request_id, request_json, request_headers)
 
+    session = SessionInfo()
+    session.request_json = request_json
+    session.request_headers = request_headers
+
+    item = ChatGPTRequestItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "request"
     assert accesslog.content == text_content
@@ -2026,16 +296,19 @@ def test_request_item_to_accesslog_array_content_textonly(messages, request_json
 
 
 def test_request_item_to_accesslog_array_content_notext(messages, request_json, request_headers, functions, tools):
-    request_id = str(uuid4())
     request_json["functions"] = functions
     request_json["tools"] = tools
     urls = [{"type": "image_url", "image_url": "url1"}, {"type": "image_url", "image_url": "url2"}]
     request_json["messages"][0]["content"] = urls
-    item = ChatGPTRequestItem(request_id, request_json, request_headers)
 
+    session = SessionInfo()
+    session.request_json = request_json
+    session.request_headers = request_headers
+
+    item = ChatGPTRequestItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "request"
     assert accesslog.content == json.dumps(urls)
@@ -2047,16 +320,20 @@ def test_request_item_to_accesslog_array_content_notext(messages, request_json, 
 
 
 def test_request_item_to_accesslog_array_content_includetext(messages, request_json, request_headers, functions, tools):
-    request_id = str(uuid4())
     request_json["functions"] = functions
     request_json["tools"] = tools
     text_content = request_json["messages"][0]["content"]
     request_json["messages"][0]["content"] = [{"type": "image_url", "image_url": "url1"}, {"type": "image_url", "image_url": "url2"}, {"type": "text", "text": text_content}]
-    item = ChatGPTRequestItem(request_id, request_json, request_headers)
 
+    session = SessionInfo()
+    session.request_json = request_json
+    session.request_headers = request_headers
+
+    item = ChatGPTRequestItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "request"
     assert accesslog.content == text_content
@@ -2067,34 +344,18 @@ def test_request_item_to_accesslog_array_content_includetext(messages, request_j
     assert accesslog.model == request_json["model"]
 
 
-def test_request_item_to_from_json(messages, request_json, request_headers, functions, tools):
-    request_id = str(uuid4())
-    request_json["functions"] = functions
-    request_json["tools"] = tools
-    item = ChatGPTRequestItem(request_id, request_json, request_headers)
-
-    item_json = item.to_json()
-    item_dict = json.loads(item_json)
-
-    assert item_dict["type"] == ChatGPTRequestItem.__name__
-    assert item_dict["request_id"] == request_id
-    assert item_dict["request_json"] == request_json
-    assert item_dict["request_headers"] == request_headers
-
-    item_restore = ChatGPTRequestItem.from_json(item_json)
-
-    assert item_restore.request_id == request_id
-    assert item_restore.request_json == request_json
-    assert item_restore.request_headers == request_headers    
-
-
 def test_response_item_to_accesslog(response_json, response_headers):
-    request_id = str(uuid4())
-    item = ChatGPTResponseItem(request_id, response_json, response_headers, 1.0, 2.0, 200)
+    session = SessionInfo()
+    session.response_json = response_json
+    session.response_headers = response_headers
+    session.duration = 2.0
+    session.duration_api = 1.0
+    session.status_code = 200
 
+    item = ChatGPTResponseItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "response"
     assert accesslog.status_code == 200
@@ -2111,16 +372,20 @@ def test_response_item_to_accesslog(response_json, response_headers):
 
 
 def test_response_item_to_accesslog_function(response_json, response_headers):
-    request_id = str(uuid4())
-
     response_json["choices"][0]["message"]["content"] = ""
     response_json["choices"][0]["message"]["function_call"] = {"name": "get_weather", "arguments": '{\n  "location": "東京"\n}'}
-    
-    item = ChatGPTResponseItem(request_id, response_json, response_headers, 1.0, 2.0, 200)
 
+    session = SessionInfo()
+    session.response_json = response_json
+    session.response_headers = response_headers
+    session.duration = 2.0
+    session.duration_api = 1.0
+    session.status_code = 200
+
+    item = ChatGPTResponseItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "response"
     assert accesslog.status_code == 200
@@ -2137,19 +402,23 @@ def test_response_item_to_accesslog_function(response_json, response_headers):
 
 
 def test_response_item_to_accesslog_tools(response_json, response_headers):
-    request_id = str(uuid4())
-
     response_json["choices"][0]["message"]["content"] = ""
     response_json["choices"][0]["message"]["tool_calls"] = [
         {"type": "function", "function": {"name": "get_weather", "arguments": '{\n  "location": "東京"\n}'}},
         {"type": "function", "function": {"name": "get_weather", "arguments": '{\n  "location": "名古屋"\n}'}},
     ]
 
-    item = ChatGPTResponseItem(request_id, response_json, response_headers, 1.0, 2.0, 200)
+    session = SessionInfo()
+    session.response_json = response_json
+    session.response_headers = response_headers
+    session.duration = 2.0
+    session.duration_api = 1.0
+    session.status_code = 200
 
+    item = ChatGPTResponseItem.from_session(session)
     accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "response"
     assert accesslog.status_code == 200
@@ -2165,93 +434,88 @@ def test_response_item_to_accesslog_tools(response_json, response_headers):
     assert accesslog.request_time_api == item.duration_api
 
 
-def test_stream_response_item_to_accesslog(chunks_json, request_json, response_headers):
-    request_id = str(uuid4())
-    chunks = []
-    content = ""
-    for c in chunks_json:
-        chunks.append(ChatGPTStreamResponseItem(request_id, c))
-        if c["choices"] and c["choices"][0]["delta"]["content"]:
-            content += c["choices"][0]["delta"]["content"]
+def test_stream_response_item_to_accesslog(chunked_content, response_headers, request_json):
+    session = SessionInfo()
+    session.request_json = request_json
+    session.response_body = chunked_content
+    session.response_headers = response_headers
+    session.duration = 2.0
+    session.duration_api = 1.0
+    session.status_code = 200
 
-    last_chunk = ChatGPTStreamResponseItem(request_id, duration=1.0, duration_api=2.0, request_json=request_json, response_headers=response_headers, status_code=200)
-    accesslog = last_chunk.to_accesslog(chunks, AccessLog)
+    item = ChatGPTStreamResponseItem.from_session(session)
+    accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "response"
     assert accesslog.status_code == 200
-    assert accesslog.content == content
+    assert accesslog.content == "はい、おしゃべりできます！何をお話ししましょうか？"
     assert accesslog.function_call is None
     assert accesslog.tool_calls is None
-    assert accesslog.raw_body == json.dumps(chunks_json, ensure_ascii=False)
+    assert accesslog.raw_body == chunked_content
     assert accesslog.raw_headers == json.dumps(response_headers, ensure_ascii=False)
-    assert accesslog.model == chunks_json[0]["model"]
+    assert accesslog.model == "gpt-3.5-turbo-0125"
     assert accesslog.prompt_tokens > 0
     assert accesslog.completion_tokens > 0
-    assert accesslog.request_time == last_chunk.duration
-    assert accesslog.request_time_api == last_chunk.duration_api
+    assert accesslog.request_time == item.duration
+    assert accesslog.request_time_api == item.duration_api
 
 
-def test_stream_response_item_to_accesslog_function(chunks_function, request_json, response_headers):
-    request_id = str(uuid4())
-    chunks = []
-    function_call = {"name": "", "arguments": ""}
-    for c in chunks_function:
-        chunks.append(ChatGPTStreamResponseItem(request_id, c))
-        if c["choices"] and c["choices"][0]["delta"]["function_call"]:
-            if not function_call["name"] and c["choices"][0]["delta"]["function_call"]["name"]:
-                function_call["name"] = c["choices"][0]["delta"]["function_call"]["name"]
-            function_call["arguments"] += c["choices"][0]["delta"]["function_call"]["arguments"]
+def test_stream_response_item_to_accesslog_function(chunked_function, request_json, response_headers):
+    session = SessionInfo()
+    session.request_json = request_json
+    session.response_body = chunked_function
+    session.response_headers = response_headers
+    session.duration = 2.0
+    session.duration_api = 1.0
+    session.status_code = 200
 
-    last_chunk = ChatGPTStreamResponseItem(request_id, duration=1.0, duration_api=2.0, request_json=request_json, response_headers=response_headers, status_code=200)
-    accesslog = last_chunk.to_accesslog(chunks, AccessLog)
+    item = ChatGPTStreamResponseItem.from_session(session)
+    accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "response"
     assert accesslog.status_code == 200
     assert accesslog.content == ""
-    assert accesslog.function_call == json.dumps(function_call, ensure_ascii=False)
+    assert accesslog.function_call == json.dumps({"name": "get_weather", "arguments": "{\"location\":\"名古屋\"}"}, ensure_ascii=False)
     assert accesslog.tool_calls is None
-    assert accesslog.raw_body == json.dumps(chunks_function, ensure_ascii=False)
+    assert accesslog.raw_body == chunked_function
     assert accesslog.raw_headers == json.dumps(response_headers, ensure_ascii=False)
-    assert accesslog.model == chunks_function[0]["model"]
+    assert accesslog.model == "gpt-3.5-turbo-0125"
     assert accesslog.prompt_tokens > 0
     assert accesslog.completion_tokens > 0
-    assert accesslog.request_time == last_chunk.duration
-    assert accesslog.request_time_api == last_chunk.duration_api
+    assert accesslog.request_time == item.duration
+    assert accesslog.request_time_api == item.duration_api
 
 
-def test_stream_response_item_to_accesslog_tools(chunks_tools, request_json, response_headers):
-    request_id = str(uuid4())
-    chunks = []
-    tool_calls = []
-    for c in chunks_tools:
-        chunks.append(ChatGPTStreamResponseItem(request_id, c))
-        if c["choices"] and c["choices"][0]["delta"]["tool_calls"]:
-            if c["choices"][0]["delta"]["tool_calls"][0]["type"] is not None:
-                tool_calls.append({"type": "function", "function": {"name": c["choices"][0]["delta"]["tool_calls"][0]["function"]["name"], "arguments": ""}})
-            elif c["choices"][0]["delta"]["tool_calls"][0]["function"].get("arguments"):
-                tool_calls[-1]["function"]["arguments"] += c["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"]
+def test_stream_response_item_to_accesslog_tools(chunked_tools, request_json, response_headers):
+    session = SessionInfo()
+    session.request_json = request_json
+    session.response_body = chunked_tools
+    session.response_headers = response_headers
+    session.duration = 2.0
+    session.duration_api = 1.0
+    session.status_code = 200
 
-    last_chunk = ChatGPTStreamResponseItem(request_id, duration=1.0, duration_api=2.0, request_json=request_json, response_headers=response_headers, status_code=200)
-    accesslog = last_chunk.to_accesslog(chunks, AccessLog)
+    item = ChatGPTStreamResponseItem.from_session(session)
+    accesslog = item.to_accesslog(AccessLog)
 
-    assert accesslog.request_id == request_id
+    assert accesslog.request_id == session.request_id
     assert isinstance(accesslog.created_at, datetime)
     assert accesslog.direction == "response"
     assert accesslog.status_code == 200
     assert accesslog.content == ""
     assert accesslog.function_call is None
-    assert accesslog.tool_calls == json.dumps(tool_calls)
-    assert accesslog.raw_body == json.dumps(chunks_tools, ensure_ascii=False)
+    assert accesslog.tool_calls == json.dumps([{"type": "function", "function": {"name": "get_weather", "arguments": "{\"location\":\"名古屋\"}"}}], ensure_ascii=False)
+    assert accesslog.raw_body == chunked_tools
     assert accesslog.raw_headers == json.dumps(response_headers, ensure_ascii=False)
-    assert accesslog.model == chunks_tools[0]["model"]
+    assert accesslog.model == "gpt-3.5-turbo-0125"
     assert accesslog.prompt_tokens > 0
     assert accesslog.completion_tokens > 0
-    assert accesslog.request_time == last_chunk.duration
-    assert accesslog.request_time_api == last_chunk.duration_api
+    assert accesslog.request_time == item.duration
+    assert accesslog.request_time_api == item.duration_api
 
 
 @pytest.fixture
@@ -2268,56 +532,62 @@ def db(worker):
 
 @pytest.fixture
 def openai_client():
-    return Client(base_url="http://127.0.0.1:8000")
+    return Client(base_url="http://127.0.0.1:8000/chatgpt")
 
 @pytest.mark.asyncio
 async def test_request_filter_overwrite(chatgpt_proxy, request_json, request_headers):
-    request_id = str(uuid4())
     request_json["model"] = "gpt-4"
 
     chatgpt_proxy.add_filter(OverwriteFilter())
-    await chatgpt_proxy.filter_request(request_id, request_json, request_headers)
+
+    session = SessionInfo()
+    session.request_json = request_json
+    session.request_headers = request_headers
+    session.request_url = "http://127.0.0.1:8000/path/to/gpt"
+
+    await chatgpt_proxy.filter_request(session)
 
     assert request_json["model"] == "gpt-3.5-turbo"
 
 
 @pytest.mark.asyncio
 async def test_request_filter_valuereturn(chatgpt_proxy, request_json, request_headers):
-    request_id = str(uuid4())
-
     chatgpt_proxy.add_filter(ValueReturnFilter())
 
+    session = SessionInfo()
+    session.request_json = request_json
+    session.request_headers = request_headers
+    session.request_url = "http://127.0.0.1:8000/path/to/gpt"
+
     # Non-stream
-    json_response = await chatgpt_proxy.filter_request(request_id, request_json, request_headers)
+    json_response = await chatgpt_proxy.filter_request(session)
     assert isinstance(json_response, JSONResponse)
     assert json_response.headers.get("x-aiproxy-request-id") is not None
     ret = json.loads(json_response.body.decode())
     assert ret["choices"][0]["message"]["content"] == "user is required"
 
-    request_json["user"] = "uezo"
-    json_response = await chatgpt_proxy.filter_request(request_id, request_json, request_headers)
+    session.request_json["user"] = "uezo"
+    json_response = await chatgpt_proxy.filter_request(session)
     assert isinstance(json_response, JSONResponse)
     assert json_response.headers.get("x-aiproxy-request-id") is not None
     ret = json.loads(json_response.body.decode())
     assert ret["choices"][0]["message"]["content"] == "you can't use this service"
 
-    request_json["user"] = "unagi"
-    dict_response = await chatgpt_proxy.filter_request(request_id, request_json, request_headers)
-    assert isinstance(dict_response, dict)
-    assert dict_response == request_json
+    session.request_json["user"] = "unagi"
+    none_response = await chatgpt_proxy.filter_request(session)
+    assert none_response is None
 
     # Stream
-    request_json["user"] = "uezo"
-    request_json["stream"] = True
-    sse_response = await chatgpt_proxy.filter_request(request_id, request_json, request_headers)
+    session.stream = True
+    session.request_json["user"] = "uezo"
+    sse_response = await chatgpt_proxy.filter_request(session)
     assert isinstance(sse_response, EventSourceResponse)
     assert sse_response.headers.get("x-aiproxy-request-id") is not None
 
-    request_json["user"] = "unagi"
-    request_json["stream"] = True
-    dict_response = await chatgpt_proxy.filter_request(request_id, request_json, request_headers)
-    assert isinstance(dict_response, dict)
-    assert dict_response == request_json
+    session.request_json["user"] = "unagi"
+    session.request_json["stream"] = True
+    none_response = await chatgpt_proxy.filter_request(session)
+    assert none_response is None
 
 
 @pytest.mark.asyncio
@@ -2327,9 +597,9 @@ async def test_response_filter_valuereturn(chatgpt_proxy, response_json):
     chatgpt_proxy.add_filter(OverwriteResponseFilter())
 
     resp = ChatCompletion.model_validate(response_json)
-    ret = await chatgpt_proxy.filter_response(request_id, resp)
+    ret = await chatgpt_proxy.filter_response(request_id, resp.model_dump())
 
-    assert ret.choices[0].message.content == "Overwrite in filter"
+    assert ret["choices"][0]["message"]["content"] == "Overwrite in filter"
 
 
 def test_post_content(messages, request_headers, openai_client, db):
@@ -2352,7 +622,7 @@ def test_post_content(messages, request_headers, openai_client, db):
 
     assert db_request.content == messages[-1]["content"]
     assert db_resonse.content == comp_resp.choices[0].message.content
-    assert json.loads(db_resonse.raw_body) == comp_resp.model_dump()    
+    assert json.loads(db_resonse.raw_body) == json.loads(api_resp.content)
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2364,6 +634,7 @@ def test_post_content(messages, request_headers, openai_client, db):
     assert db_resonse.status_code == api_resp.status_code
 
 # NOTE: Restart AIProxy instance with custom log worker before this case
+@pytest.mark.skip("skip")
 def test_post_content_custom_log(messages, request_headers, openai_client, db):
     extra_headers = {
         "x-user-id": "user_1234567890",
@@ -2390,7 +661,7 @@ def test_post_content_custom_log(messages, request_headers, openai_client, db):
 
     assert db_request.content == messages[-1]["content"]
     assert db_resonse.content == comp_resp.choices[0].message.content
-    assert json.loads(db_resonse.raw_body) == comp_resp.model_dump()    
+    assert json.loads(db_resonse.raw_body) == json.loads(api_resp.content)
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2404,6 +675,7 @@ def test_post_content_custom_log(messages, request_headers, openai_client, db):
     assert db_request.user_id == extra_headers["x-user-id"]
     assert db_request.device_id == extra_headers["x-device-id"]
     assert db_request.ip_address == extra_headers["x-ip-address"]
+
 
 def test_post_content_function(messages, request_headers, functions, openai_client, db):
     api_resp = openai_client.chat.completions.with_raw_response.create(
@@ -2427,7 +699,7 @@ def test_post_content_function(messages, request_headers, functions, openai_clie
 
     assert db_request.content == messages[-1]["content"]
     assert json.loads(db_resonse.function_call) == function_call.model_dump()
-    assert json.loads(db_resonse.raw_body) == comp_resp.model_dump()    
+    assert json.loads(db_resonse.raw_body) == json.loads(api_resp.content)
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2437,6 +709,7 @@ def test_post_content_function(messages, request_headers, functions, openai_clie
     assert "openai-model" in db_headers
     assert "openai-processing-ms" in db_headers
     assert db_resonse.status_code == api_resp.status_code
+
 
 def test_post_content_tools(messages, request_headers, tools, openai_client, db):
     api_resp = openai_client.chat.completions.with_raw_response.create(
@@ -2460,7 +733,7 @@ def test_post_content_tools(messages, request_headers, tools, openai_client, db)
 
     assert db_request.content == messages[-1]["content"]
     assert json.loads(db_resonse.tool_calls) == [t.model_dump() for t in tool_calls]
-    assert json.loads(db_resonse.raw_body) == comp_resp.model_dump()    
+    assert json.loads(db_resonse.raw_body) == json.loads(api_resp.content)   
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2494,7 +767,6 @@ def test_post_content_apierror(messages, request_headers, openai_client, db):
     db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "error").first()
 
     assert db_request.content == messages[-1]["content"]
-    assert str(apisterr.value) in db_resonse.content
     assert db_resonse.status_code == api_resp.status_code
 
 
@@ -2503,28 +775,33 @@ def test_post_content_stream(messages, request_headers, openai_client, db):
         model="gpt-3.5-turbo", messages=messages, stream=True
     )
 
-    comp_resp = api_resp.parse()
     headers = api_resp.headers
-
     request_id = headers.get("x-aiproxy-request-id")
     assert request_id is not None
 
-    chunks = []
+    chunks = ""
     content = ""
-    for chunk in comp_resp:
-        chunks.append(chunk.model_dump())
-        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
-            content += chunk.choices[0].delta.content
+    for b in api_resp.http_response.iter_raw():
+        chunk_str = b.decode("utf-8")
+        chunk_str = chunk_str.replace("\r", "").replace("event: \n", "")
+        chunks += chunk_str
+        for data_str in chunk_str.split("\n\n"):
+            if "data:" in data_str:
+                try:
+                    chunk = json.loads(chunk_str.split("data:")[1])
+                    content += chunk["choices"][0]["delta"]["content"]
+                except:
+                    pass
 
     # Wait for processing queued items
-    sleep(10.0)
+    sleep(5.0)
 
     db_request = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "request").first()
     db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "response").first()
 
     assert db_request.content == messages[-1]["content"]
     assert db_resonse.content == content
-    assert json.loads(db_resonse.raw_body) == chunks
+    assert db_resonse.raw_body == chunks
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2541,21 +818,28 @@ def test_post_content_stream_function(messages, request_headers, functions, open
         model="gpt-3.5-turbo", messages=messages, stream=True, functions=functions
     )
 
-    comp_resp = api_resp.parse()
     headers = api_resp.headers
 
     request_id = headers.get("x-aiproxy-request-id")
     assert request_id is not None
 
-    chunks = []
+    chunks = ""
     function_call = {"name": "", "arguments": ""}
-    for chunk in comp_resp:
-        chunks.append(chunk.model_dump())
-        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.function_call:
-            if chunk.choices[0].delta.function_call.name and not function_call["name"]:
-                function_call["name"] = chunk.choices[0].delta.function_call.name
-            else:
-                function_call["arguments"] += chunk.choices[0].delta.function_call.arguments
+    for b in api_resp.http_response.iter_raw():
+        chunk_str = b.decode("utf-8")
+        chunk_str = chunk_str.replace("\r", "").replace("event: \n", "")
+        chunks += chunk_str
+        for data_str in chunk_str.split("\n\n"):
+            if "data:" in data_str:
+                try:
+                    chunk = json.loads(chunk_str.split("data:")[1])
+                    if "choices" in chunk and "delta" in chunk["choices"][0] and "function_call" in chunk["choices"][0]["delta"]:
+                        if "name" in chunk["choices"][0]["delta"]["function_call"] and not function_call["name"]:
+                            function_call["name"] = chunk["choices"][0]["delta"]["function_call"]["name"]
+                        else:
+                            function_call["arguments"] += chunk["choices"][0]["delta"]["function_call"]["arguments"]
+                except:
+                    pass
 
     # Wait for processing queued items
     sleep(10.0)
@@ -2565,7 +849,7 @@ def test_post_content_stream_function(messages, request_headers, functions, open
 
     assert db_request.content == messages[-1]["content"]
     assert json.loads(db_resonse.function_call) == function_call
-    assert json.loads(db_resonse.raw_body) == chunks
+    assert db_resonse.raw_body == chunks
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2582,21 +866,28 @@ def test_post_content_stream_tools(messages, request_headers, tools, openai_clie
         model="gpt-3.5-turbo", messages=messages, stream=True, tools=tools
     )
 
-    comp_resp = api_resp.parse()
     headers = api_resp.headers
 
     request_id = headers.get("x-aiproxy-request-id")
     assert request_id is not None
 
-    chunks = []
+    chunks = ""
     tool_calls = []
-    for chunk in comp_resp:
-        chunks.append(chunk.model_dump())
-        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.tool_calls:
-            if chunk.choices[0].delta.tool_calls[0].type is not None:
-                tool_calls.append({"type": "function", "function": {"name": chunk.choices[0].delta.tool_calls[0].function.name, "arguments": ""}})
-            elif chunk.choices[0].delta.tool_calls[0].function.arguments:
-                tool_calls[-1]["function"]["arguments"] += chunk.choices[0].delta.tool_calls[0].function.arguments
+    for b in api_resp.http_response.iter_raw():
+        chunk_str = b.decode("utf-8")
+        chunk_str = chunk_str.replace("\r", "").replace("event: \n", "")
+        chunks += chunk_str
+        for data_str in chunk_str.split("\n\n"):
+            if "data:" in data_str:
+                try:
+                    chunk = json.loads(chunk_str.split("data:")[1])
+                    if "choices" in chunk and "delta" in chunk["choices"][0] and "tool_calls" in chunk["choices"][0]["delta"]:
+                        if "type" in chunk["choices"][0]["delta"]["tool_calls"][0] and chunk["choices"][0]["delta"]["tool_calls"][0]["type"] is not None:
+                            tool_calls.append({"type": "function", "function": {"name": chunk["choices"][0]["delta"]["tool_calls"][0]["function"]["name"], "arguments": ""}})
+                        else:
+                            tool_calls[-1]["function"]["arguments"] += chunk["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"]
+                except:
+                    pass
 
     # Wait for processing queued items
     sleep(10.0)
@@ -2606,7 +897,7 @@ def test_post_content_stream_tools(messages, request_headers, tools, openai_clie
 
     assert db_request.content == messages[-1]["content"]
     assert json.loads(db_resonse.tool_calls) == tool_calls
-    assert json.loads(db_resonse.raw_body) == chunks
+    assert db_resonse.raw_body == chunks
     # NOTE: It doesn't completely same because FastAPI/Uvicorn adds some values. (e.g. date, server)
     # 'date': 'Mon, 11 Dec 2023 14:06:05 GMT, Mon, 11 Dec 2023 14:06:08 GMT'
     # 'server': 'uvicorn, cloudflare'
@@ -2640,5 +931,4 @@ def test_post_content_stream_apierror(messages, request_headers, openai_client, 
     db_resonse = db.query(AccessLog).where(AccessLog.request_id == request_id, AccessLog.direction == "error").first()
 
     assert db_request.content == messages[-1]["content"]
-    assert str(apisterr.value) in db_resonse.content
     assert db_resonse.status_code == api_resp.status_code


### PR DESCRIPTION
Replace official LLM API client with httpx.

This change involves switching from using the official LLM API client to directly handling HTTP requests and responses using httpx.

The primary reasons for this change include performance improvements, standardization of processing, and enhanced maintainability. This update should make the system more efficient and easier to manage.