### PR TITLE
Experimentally extend support to additional API endpoints🧪

### DIFF
--- a/aiproxy/__main__.py
+++ b/aiproxy/__main__.py
@@ -41,6 +41,6 @@ proxy = ChatGPTProxy(api_key=args.openai_api_key, access_logger_queue=worker.que
 
 # Setup server application
 app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
-proxy.add_route(app, "/chat/completions")
+proxy.add_route(app)
 
 uvicorn.run(app, host=args.host, port=args.port)

--- a/aiproxy/anthropic_claude.py
+++ b/aiproxy/anthropic_claude.py
@@ -86,9 +86,6 @@ class ClaudeStreamResponseItem(SessionStreamChunkItemBase):
             if len(chunk_split) < 2:
                 continue    # Skip invalid data
 
-            print("====")
-            print(chunk_split[1])
-
             chunk_json = json.loads(chunk_split[1].strip())
 
             # Get metadata of request
@@ -157,7 +154,9 @@ class ClaudeProxy(HTTPXProxy):
         )
 
         self.api_key = api_key
-        self.api_base_url = "https://api.anthropic.com/v1/messages"
+        self.api_base_url = "https://api.anthropic.com/v1"
+        self.api_chat_resource_path = "/messages"
+        self.api_service_id = "anthropic"
 
     def text_to_response_json(self, text: str) -> dict:
         return {

--- a/aiproxy/chatgpt.py
+++ b/aiproxy/chatgpt.py
@@ -240,7 +240,9 @@ class ChatGPTProxy(HTTPXProxy):
         )
 
         self.api_key = api_key
-        self.api_base_url = "https://api.openai.com/v1/chat/completions"
+        self.api_base_url = "https://api.openai.com/v1"
+        self.api_chat_resource_path = "/chat/completions"
+        self.api_service_id = "openai"
 
     def text_to_response_json(self, text: str) -> dict:
         return {

--- a/tests/test_anthropic_claude.py
+++ b/tests/test_anthropic_claude.py
@@ -802,7 +802,7 @@ async def test_response_filter_valuereturn(claude_proxy, response_json):
 
 def test_post_content(prompt_text, request_json, request_headers, db):
     response = httpx.post(
-        url="http://127.0.0.1:8000/claude/v1/messages",
+        url="http://127.0.0.1:8000/anthropic/messages",
         headers={
             "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
             "anthropic-version": "2023-06-01"
@@ -831,7 +831,7 @@ def test_post_content_apierror(prompt_text, request_json, request_headers, db):
     with pytest.raises(HTTPStatusError) as status_error:
         request_json["max_tokens"] = 999999999
         httpx.post(
-            url="http://127.0.0.1:8000/claude/v1/messages",
+            url="http://127.0.0.1:8000/anthropic/messages",
             headers={
                 "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                 "anthropic-version": "2023-06-01"
@@ -861,7 +861,7 @@ def test_post_content_stream(prompt_text, request_json, request_headers, db):
     request_json["stream"] = True
     request = httpx.Request(
         method="POST",
-        url="http://127.0.0.1:8000/claude/v1/messages",
+        url="http://127.0.0.1:8000/anthropic/messages",
         headers={
             "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
             "anthropic-version": "2023-06-01"
@@ -901,7 +901,7 @@ def test_post_content_stream_apierror(prompt_text, request_json, request_headers
         request_json["max_tokens"] = 999999999
         request = httpx.Request(
             method="POST",
-            url="http://127.0.0.1:8000/claude/v1/messages",
+            url="http://127.0.0.1:8000/anthropic/messages",
             headers={
                 "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                 "anthropic-version": "2023-06-01",

--- a/tests/test_chatgpt.py
+++ b/tests/test_chatgpt.py
@@ -532,7 +532,7 @@ def db(worker):
 
 @pytest.fixture
 def openai_client():
-    return Client(base_url="http://127.0.0.1:8000/chatgpt")
+    return Client(base_url="http://127.0.0.1:8000/openai")
 
 @pytest.mark.asyncio
 async def test_request_filter_overwrite(chatgpt_proxy, request_json, request_headers):


### PR DESCRIPTION
Experimentally implement support for additional API endpoints

This commit adds experimental support for handling non-chat API endpoints such as embeddings and model listings. The feature is experimental and aims to assess the feasibility of expanding the reverse proxy's capabilities to a wider range of services.

Unlike the chat API, which records various extracted information in separate columns in addition to the bodies and headers, this implementation simply logs the headers and bodies for non-chat APIs without additional processing.