### PR TITLE
Make it easier to set base_url for API clients

### DIFF
--- a/aiproxy/anthropic_claude.py
+++ b/aiproxy/anthropic_claude.py
@@ -154,8 +154,8 @@ class ClaudeProxy(HTTPXProxy):
         )
 
         self.api_key = api_key
-        self.api_base_url = "https://api.anthropic.com/v1"
-        self.api_chat_resource_path = "/messages"
+        self.api_base_url = "https://api.anthropic.com"
+        self.api_chat_resource_path = "/v1/messages"
         self.api_service_id = "anthropic"
 
     def text_to_response_json(self, text: str) -> dict:

--- a/aiproxy/chatgpt.py
+++ b/aiproxy/chatgpt.py
@@ -240,8 +240,8 @@ class ChatGPTProxy(HTTPXProxy):
         )
 
         self.api_key = api_key
-        self.api_base_url = "https://api.openai.com/v1"
-        self.api_chat_resource_path = "/chat/completions"
+        self.api_base_url = "https://api.openai.com"
+        self.api_chat_resource_path = "/v1/chat/completions"
         self.api_service_id = "openai"
 
     def text_to_response_json(self, text: str) -> dict:

--- a/tests/test_anthropic_claude.py
+++ b/tests/test_anthropic_claude.py
@@ -802,7 +802,7 @@ async def test_response_filter_valuereturn(claude_proxy, response_json):
 
 def test_post_content(prompt_text, request_json, request_headers, db):
     response = httpx.post(
-        url="http://127.0.0.1:8000/anthropic/messages",
+        url="http://127.0.0.1:8000/anthropic/v1/messages",
         headers={
             "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
             "anthropic-version": "2023-06-01"
@@ -831,7 +831,7 @@ def test_post_content_apierror(prompt_text, request_json, request_headers, db):
     with pytest.raises(HTTPStatusError) as status_error:
         request_json["max_tokens"] = 999999999
         httpx.post(
-            url="http://127.0.0.1:8000/anthropic/messages",
+            url="http://127.0.0.1:8000/anthropic/v1/messages",
             headers={
                 "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                 "anthropic-version": "2023-06-01"
@@ -861,7 +861,7 @@ def test_post_content_stream(prompt_text, request_json, request_headers, db):
     request_json["stream"] = True
     request = httpx.Request(
         method="POST",
-        url="http://127.0.0.1:8000/anthropic/messages",
+        url="http://127.0.0.1:8000/anthropic/v1/messages",
         headers={
             "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
             "anthropic-version": "2023-06-01"
@@ -901,7 +901,7 @@ def test_post_content_stream_apierror(prompt_text, request_json, request_headers
         request_json["max_tokens"] = 999999999
         request = httpx.Request(
             method="POST",
-            url="http://127.0.0.1:8000/anthropic/messages",
+            url="http://127.0.0.1:8000/anthropic/v1/messages",
             headers={
                 "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                 "anthropic-version": "2023-06-01",


### PR DESCRIPTION
Enable routing API clients through a custom proxy by setting base_url

This change allows API clients like OpenAI and Anthropic to easily configure their base_url to route requests through a specified proxy server. This simplifies the integration of various services through a unified proxy endpoint, offering better control over API traffic and network architecture.

Examples:

- For OpenAI client:

```python
client = openai.Client(
    api_key="YOUR_API_KEY",
    base_url="http://127.0.0.1:8000/openai"
)
```

- For Anthropic client:

```python
client = Anthropic(
    api_key="YOUR_API_KEY",
    base_url="http://127.0.0.1:8000/anthropic"
)
```