### PR TITLE
Extend aiproxy command support for Claude3 and Gemini

### DIFF
--- a/aiproxy/__init__.py
+++ b/aiproxy/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.4.1"
+
 import logging
 
 logger = logging.getLogger("aiproxy")

--- a/aiproxy/__main__.py
+++ b/aiproxy/__main__.py
@@ -1,24 +1,38 @@
 import argparse
 from contextlib import asynccontextmanager
+import logging
 import os
-from fastapi import FastAPI
-from aiproxy import ChatGPTProxy, AccessLogWorker
 import threading
 import uvicorn
+from fastapi import FastAPI
+from aiproxy import AccessLogWorker, __version__
+from aiproxy.chatgpt import ChatGPTProxy
+from aiproxy.anthropic_claude import ClaudeProxy
+from aiproxy.gemini import GeminiProxy
+
+logger = logging.getLogger("aiproxy")
+logger.addHandler(logging.NullHandler())
 
 # Get API Key from env
 env_openai_api_key = os.getenv("OPENAI_API_KEY")
+env_anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+env_google_api_key = os.getenv("GOOGLE_API_KEY")
 
 # Get arguments
 parser = argparse.ArgumentParser(description="AIProxy usage")
 parser.add_argument("--host", type=str, default="127.0.0.1", required=False, help="hostname or ipaddress")
 parser.add_argument("--port", type=int, default="8000", required=False, help="port number")
 parser.add_argument("--openai_api_key", type=str, default=env_openai_api_key, required=False, help="OpenAI API Key")
+parser.add_argument("--anthropic_api_key", type=str, default=env_anthropic_api_key, required=False, help="Anthropic API Key")
+parser.add_argument("--google_api_key", type=str, default=env_google_api_key, required=False, help="Google API Key")
+parser.add_argument("--connection_str", type=str, default="sqlite:///aiproxy.db", required=False, help="Database connection string")
+
 args = parser.parse_args()
 
 # Setup access log worker
-worker = AccessLogWorker()
+worker = AccessLogWorker(connection_str=args.connection_str)
 
+# Setup server application
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Start access log worker
@@ -27,11 +41,29 @@ async def lifespan(app: FastAPI):
     # Stop access log worker
     worker.queue_client.put(None)
 
-# Setup ChatGPTProxy
-proxy = ChatGPTProxy(api_key=args.openai_api_key, access_logger_queue=worker.queue_client)
-
-# Setup server application
 app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
-proxy.add_route(app)
+
+# ChatGPT Proxy
+chatgpt_proxy = ChatGPTProxy(
+    api_key=args.openai_api_key,
+    access_logger_queue=worker.queue_client
+)
+chatgpt_proxy.add_route(app)
+
+# Proxy for Anthropic Claude
+claude_proxy = ClaudeProxy(
+    api_key=args.anthropic_api_key,
+    access_logger_queue=worker.queue_client
+)
+claude_proxy.add_route(app)
+
+# Proxy for Gemini on Google AI Studio (not Vertex AI)
+gemini_proxy = GeminiProxy(
+    api_key=args.google_api_key,
+    access_logger_queue=worker.queue_client
+)
+gemini_proxy.add_route(app)
+
+logger.info(f"Start AI Proxy version {__version__}")
 
 uvicorn.run(app, host=args.host, port=args.port)

--- a/aiproxy/chatgpt.py
+++ b/aiproxy/chatgpt.py
@@ -240,8 +240,8 @@ class ChatGPTProxy(HTTPXProxy):
         )
 
         self.api_key = api_key
-        self.api_base_url = "https://api.openai.com"
-        self.api_chat_resource_path = "/v1/chat/completions"
+        self.api_base_url = "https://api.openai.com/v1"
+        self.api_chat_resource_path = "/chat/completions"
         self.api_service_id = "openai"
 
     def text_to_response_json(self, text: str) -> dict:


### PR DESCRIPTION
Enhance aiproxy to initiate proxies for Claude3 and Gemini

This update adds support for Claude3 and Gemini in the `aiproxy` command, expanding the range of AI models that can be managed through the proxy.

API keys can be configured as follows:
- Via environment variables: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY
- Via command-line arguments: --openai_api_key, --anthropic_api_key, --google_api_key