### PR TITLE
Add support for Azure OpenAI Service

### DIFF
--- a/aiproxy/__init__.py
+++ b/aiproxy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
+from aiproxy import __version__
 
 setup(
     name="aiproxy-python",
-    version="0.3.6",
+    version=__version__,
     url="https://github.com/uezo/aiproxy",
     author="uezo",
     author_email="uezo@uezo.net",
@@ -12,7 +13,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     install_requires=[
-        "openai==1.3.6",
+        "httpx==0.27.0",
         "fastapi==0.103.2",
         "uvicorn==0.23.2",
         "sse-starlette==1.8.2",


### PR DESCRIPTION
Just the chat completion is supported for now.

To use Azure OpenAI, use `AzureOpenAIProxy` instead of `ChatGPTProxy`.

```python
from aiproxy.chatgpt import AzureOpenAIProxy

aoai_proxy = AzureOpenAIProxy(
    api_key="YOUR_API_KEY",
    resource_name="YOUR_RESOURCE_NAME",
    deployment_id="YOUR_DEPLOYMENT_ID",
    api_version="2024-02-01",   # https://learn.microsoft.com/ja-jp/azure/ai-services/openai/reference#chat-completions
    access_logger_queue=worker.queue_client
)
aoai_proxy.add_route(app)
```

Clients do not need to be aware that it is Azure OpenAI; use the same code for ChatGPT API.
